### PR TITLE
No data status

### DIFF
--- a/dax/task.py
+++ b/dax/task.py
@@ -250,6 +250,8 @@ class Task(object):
         elif old_status == UPLOADING:
             # TODO: can we see if it's really uploading???
             pass
+        elif old_status == NO_DATA:
+            pass
         else:
             print('\t *ERROR:unknown status:'+old_status)
             


### PR DESCRIPTION
Hi,

This pull_request has one purpose: add the status NO_DATA to the assessors. When an assessor is created, if the has_inputs() return 1, status will be NEED_TO_RUN, if return -1; status will be NO_DATA, if return 0, status will be NEED_INPUTS.

should_run() for a session should be set to return True and should always create an assessor.
