### PR TITLE
Executable to generate processors modules

### DIFF
--- a/bin/dax_tools/GenerateModuleTemplate
+++ b/bin/dax_tools/GenerateModuleTemplate
@@ -1,0 +1,293 @@
+"""
+    Title: GenerateModuleTemplate
+    Author: Benjamin Yvernault
+    contact: b.yvernault@ucl.ac.uk
+    Purpose:
+        Generate your module.py following the template for module describe in this file.
+"""
+
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+__author__ = 'Benjamin Yvernault'
+__email__ = 'b.yvernault@ucl.ac.uk'
+__purpose__ = "Generate your module.py following the template for module describe in this file."
+__version__ = '1.0.0'
+__modifications__ = '24 August 2015 - Original write'
+
+import os
+from datetime import datetime
+
+DEFAULT_TEMPLATE = """'''
+    Author:         {author}
+    contact:        {email_addr}
+    Module name:    Module_{name}
+    Creation date:  {now}
+    Purpose:        {purpose}
+'''
+
+__author__ = "{author}"
+__email__ = "{email_addr}"
+__purpose__ = "{purpose}"
+__module_name__ = "Module_{name}"
+__modifications__ = "{now} - Original write"
+
+# Python packages import
+import os
+import logging
+from dax import XnatUtils, ScanModule, SessionModule
+
+# set-up logger for printing statements
+LOGGER = logging.getLogger('dax')
+
+# Default values for arguments:
+# EDIT PARAMETERS FOR YOUR MODULE CASE
+DEFAULT_TPM_PATH = '/tmp/{name}_temp/'
+DEFAULT_MODULE_NAME = '{name}'
+DEFAULT_TEXT_REPORT = 'ERROR/WARNING for {name} :\\n'
+"""
+
+SCAN_LEVEL_TEMPLATE = DEFAULT_TEMPLATE+"""
+class Module_{name}(ScanModule):
+    '''
+    Module class for {name} that runs on a scan
+
+    :param mod_name: module name
+    :param directory: temp directory for the module temporary files
+    :param email: email address to send error/warning to
+    :param text_report: title for the report
+    #
+    # ADD MORE PARAMETERS AS NEEDED HERE
+    #
+    '''
+    def __init__(self, mod_name=DEFAULT_MODULE_NAME, directory=DEFAULT_TPM_PATH, email=None,
+                 text_report=DEFAULT_TEXT_REPORT):
+        super(Module_{name}, self).__init__(mod_name, directory, email, text_report=text_report)
+        #
+        # ADD MORE PARAMETERS AS NEEDED HERE LIKE self.param = param
+        #
+
+    def prerun(self, settings_filename=''):
+        '''
+        prerun function overridden from base-class
+        method that runs at the beginning, before looping over the sessions for the project
+
+        :param settings_filename: settings file name to set the temporary folder
+        '''
+        # make temporary directory using the settings filename
+        self.make_dir(settings_filename)
+
+        #
+        # ADD CODE HERE IF YOU NEED TO EXECUTE SOMETHING BEFORE THE LOOP
+        #
+
+    def afterrun(self, xnat, project):
+        '''
+        afterrun function overridden from base-class
+        method that runs at the end, after looping over the sessions for the project
+
+        :param xnat: interface to xnat object (XnatUtils.get_interface())
+        :param project: project ID/label on XNAT
+        '''
+        #
+        # ADD CODE HERE IF YOU NEED TO EXECUTE SOMETHING AFTER THE LOOP
+        #
+
+        # send report
+        if self.send_an_email:
+            self.send_report()
+
+        # clean the directory created
+        try:
+            os.rmdir(self.directory)
+        except:
+            LOGGER.warn('{name} -- afterrun -- '+self.directory+' not empty. Could not delete it.')
+
+    def needs_run(self, cscan, xnat):
+        '''
+        needs_run function overridden from base-class
+        method that runs before each loop step to check if we need to run on this scan
+
+        :param cscan: CacheScan object from XnatUtils
+        :param xnat: interface to xnat object (XnatUtils.get_interface())
+        :return: boolean, True if needs to run
+        '''
+        #
+        # CODE TO CHECK IF THE MODULE NEEDS TO RUN FOR THE SCAN DEFINE BY CSCAN
+        #
+        # EXAMPLE: CHECK IF NIFTI EXISTS AND IF THERE IS A DICOM FOR DCM2NII
+        # # Variables:
+        # scan_info = cscan.info()
+        #
+        # # Check output
+        # if XnatUtils.has_resource(cscan, 'NIFTI'):
+        #     LOGGER.debug('Has NIFTI')
+        #     return False
+        # # Check input
+        # if not XnatUtils.has_resource(cscan, 'DICOM'):
+        #     LOGGER.debug('no DICOM resource')
+        #     return False
+
+        return True
+
+    def run(self, scan_info, scan_obj):
+        '''
+        run method: {purpose}
+          lines of code that will be executed for the scan
+
+        :param scan_info: python dictionary with information on the scan (see output of XnatUtils.list_scans)
+        :param scan_obj: pyxnat Scan object
+        '''
+        #
+        # CODE TO EXECUTE ON THE SCAN (E.G: GENERATE NIFTI/PREVIEW)
+        #
+
+        # clean temporary folder
+        self.clean_directory()
+"""
+
+SESSION_LEVEL_TEMPLATE = DEFAULT_TEMPLATE+"""
+# Resource name set on session to know that the module ran
+RESOURCE_FLAG_NAME = 'Module_{name}'
+
+class Module_{name}(SessionModule):
+    '''
+    Module class for {name} that runs on a session
+
+    :param mod_name: module name
+    :param directory: temp directory for the module temporary files
+    :param email: email address to send error/warning to
+    :param text_report: title for the report
+    #
+    # ADD MORE PARAMETERS AS NEEDED HERE
+    #
+    '''
+    def __init__(self, mod_name=DEFAULT_MODULE_NAME, directory=DEFAULT_TPM_PATH, email=None,
+                 text_report=DEFAULT_TEXT_REPORT):
+        super(Module_{name}, self).__init__(mod_name, directory, email, text_report=text_report)
+        #
+        # ADD MORE PARAMETERS AS NEEDED HERE LIKE self.param = param
+        #
+
+    def prerun(self, settings_filename=''):
+        '''
+        prerun function overridden from base-class
+        method that runs at the beginning, before looping over the sessions for the project
+
+        :param settings_filename: settings file name to set the temporary folder
+        '''
+        # make temporary directory using the settings filename
+        self.make_dir(settings_filename)
+
+        #
+        # ADD CODE HERE IF YOU NEED TO EXECUTE SOMETHING BEFORE THE LOOP
+        #
+
+    def afterrun(self, xnat, project):
+        '''
+        afterrun function overridden from base-class
+        method that runs at the end, after looping over the sessions for the project
+
+        :param xnat: interface to xnat object (XnatUtils.get_interface())
+        :param project: project ID/label on XNAT
+        '''
+        #
+        # ADD CODE HERE IF YOU NEED TO EXECUTE SOMETHING AFTER THE LOOP
+        #
+
+        # send report
+        if self.send_an_email:
+            self.send_report()
+
+        # clean the directory created
+        try:
+            os.rmdir(self.directory)
+        except:
+            LOGGER.warn('{name} -- afterrun -- '+self.directory+' not empty. Could not delete it.')
+
+    def needs_run(self, csess, xnat):
+        '''
+        needs_run function overridden from base-class
+        method that runs before each loop step to check if we need to run on this session
+
+        :param csess: CacheSession object from XnatUtils
+        :param xnat: interface to xnat object (XnatUtils.get_interface())
+        :return: boolean, True if needs to run
+        '''
+        #
+        # CODE TO CHECK IF THE MODULE NEEDS TO RUN FOR THE SESSION DEFINE BY CSESS
+        # FOR SESSION MODULE, SET A RESOURCE ON SESSION WITH FLAG NAME
+        #
+        return self.has_flag_resource(csess, RESOURCE_FLAG_NAME)
+
+    def run(self, session_info, session_obj):
+        '''
+        run method: {purpose}
+          lines of code that will be executed for the session
+
+        :param session_info: python dictionary with information on the session (see output of XnatUtils.list_sessions)
+        :param session_obj: pyxnat Session object
+        '''
+        #
+        # CODE TO EXECUTE ON THE SESSION (E.G: SET SCAN TYPE)
+        #
+
+        # clean temporary folder
+        self.clean_directory()
+
+        # create the flag resource on the session
+        session_obj.resource(RESOURCE_FLAG_NAME).create()
+"""
+
+def write_module(module_fpath, templates, args):
+    """
+    Write the Module.py with the proper template
+
+    :param module_fpath: path where the module script will be saved
+    :param templates: template to use (scan or session)
+    :param args: arguments parser
+    """
+    module_code = templates.format(author=args.author,
+                                   email_addr=args.email,
+                                   name=args.name,
+                                   now=str(datetime.now()),
+                                   purpose=args.purpose)
+    f_obj = open(module_fpath, "w")
+    f_obj.writelines(module_code)
+    f_obj.close()
+
+def parse_args():
+    """
+    Parser for arguments
+    """
+    from argparse import ArgumentParser
+    usage = "Generate a module.py file from the template for dax in a new file."
+    argp = ArgumentParser(prog='GenerateModuleTemplate', description=usage)
+    argp.add_argument('-n', dest='name', help='Name for module. E.G: dcm2nii.', required=True)
+    argp.add_argument('-a', dest='author', help='Author name.', required=True)
+    argp.add_argument('-e', dest='email', help='Author email address.', required=True)
+    argp.add_argument('-p', dest='purpose', help='Module purpose.', required=True)
+    argp.add_argument('--onScan', dest='on_scan', action='store_true', help='Use Scan type Spider.')
+    argp.add_argument('-d', dest='directory',
+                      help='Directory where the module file will be generated. Default: current directory.', default=None)
+    return argp.parse_args()
+
+if __name__ == '__main__':
+    ARGS = parse_args()
+
+    # Removing Spider if present in name
+    if "module" in ARGS.name.lower():
+        ERR = "wrong name for the module. Remove 'module' from the name."
+        raise ValueError(ERR)
+
+    MODULE_NAME = """Module_{name}.py""".format(name=ARGS.name)
+    if ARGS.directory and os.path.exists(ARGS.directory):
+        MODULE_FPATH = os.path.join(ARGS.directory, MODULE_NAME)
+    else:
+        MODULE_FPATH = os.path.join(os.getcwd(), MODULE_NAME)
+    if ARGS.on_scan:
+        print "Generating file %s for scan module %s ..." % (MODULE_FPATH, ARGS.name)
+        write_module(MODULE_FPATH, SCAN_LEVEL_TEMPLATE, ARGS)
+    else:
+        print "Generating file %s for session module %s ..." % (MODULE_FPATH, ARGS.name)
+        write_module(MODULE_FPATH, SESSION_LEVEL_TEMPLATE, ARGS)

--- a/bin/dax_tools/GenerateProcessorTemplate
+++ b/bin/dax_tools/GenerateProcessorTemplate
@@ -1,0 +1,269 @@
+"""
+    Title: GenerateProcessorTemplate
+    Author: Benjamin Yvernault
+    contact: b.yvernault@ucl.ac.uk
+    Purpose:
+        Generate your processor.py following the template for processor describe in this file.
+"""
+
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+__author__ = 'Benjamin Yvernault'
+__email__ = 'b.yvernault@ucl.ac.uk'
+__purpose__ = "Generate your processor.py following the template for processor describe in this file."
+__version__ = '1.0.0'
+__modifications__ = '24 August 2015 - Original write'
+
+import os
+from datetime import datetime
+
+DEFAULT_TEMPLATE = """'''
+    Author:         {author}
+    contact:        {email_addr}
+    Processor name: Processor_{name}
+    Creation date:  {now}
+    Purpose:        {purpose}
+'''
+
+__author__ = "{author}"
+__email__ = "{email_addr}"
+__purpose__ = "{purpose}"
+__processor_name__ = "Processor_{name}"
+__modifications__ = "{now} - Original write"
+
+# Python packages import
+import os
+import logging
+from dax_spiders import PathSettings
+from dax import XnatUtils, ScanProcessor, SessionProcessor
+
+# set-up logger for printing statements
+LOGGER = logging.getLogger('dax')
+
+# Default values for arguments:
+# EDIT PARAMETERS FOR YOUR SPIDER CASE (SPIDER_PATH, WALLTIME, etc...)
+DEFAULT_SPIDER_PATH = os.path.join(SPIDER_PATH, 'Spider_{name}_1_0_0.py')
+DEFAULT_WALLTIME = '01:00:00'
+DEFAULT_MEM = 2048
+DEFAULT_SCAN_TYPES = [] # ADD SCAN TYPES
+"""
+
+SCAN_LEVEL_TEMPLATE = DEFAULT_TEMPLATE+"""
+# Format for the spider command line
+SPIDER_FORMAT = '''python {{spider}} -v --spm {{spm}} \
+-p {{proj}} -s {{subj}} -e {{sess}} -c {{scan}} -d {{dir}} --suffix "{{suffix_proc}}"'''
+
+class Processor_{name}(ScanProcessor):
+    '''
+    Processor class for {name} that runs on a scan
+
+    :param spider_path: spider path on the system
+    :param version: version of the spider
+    :param walltime: walltime required by the spider
+    :param mem_mb: memory in Mb required by the spider
+    :param scan_types: scan types on XNAT that the spider should run on
+    :param spm_path: path to SPM
+    #
+    # ADD MORE PARAMETERS AS NEEDED HERE
+    #
+    :param suffix: suffix to the spider
+    '''
+    def __init__(self, spider_path=DEFAULT_SPIDER_PATH, version=None,
+                 walltime=DEFAULT_WALLTIME, mem_mb=DEFAULT_MEM,
+                 scan_types=DEFAULT_SCAN_TYPES, spm_path=PathSettings.SPM_PATH, suffix_proc=''):
+        super(Processor_{name}, self).__init__(scan_types, walltime, mem_mb, spider_path,
+                                               version, suffix_proc=suffix_proc)
+        self.spm_path = spm_path
+        #
+        # ADD MORE PARAMETERS AS NEEDED HERE LIKE self.param = param
+        #
+
+    def has_inputs(self, cscan):
+        '''
+        function overridden from base class
+        By definition, status = 0 if still NEED_INPUTS, -1 if NO_DATA, 1 if NEED_TO_RUN
+                       qcstatus needs a value only when -1 or 0.
+        You can set qcstatus to a short string that explain why it's no ready to run.
+            e.g: No NIFTI
+
+        :param cscan: object cscan define in dax.XnatUtils (see XnatUtils in dax for information)
+        :return: status, qcstatus
+        '''
+        #
+        # CODE TO CHECK IF THE PROCESS HAS THE INPUTS NEEDED FROM XNAT
+        # CHECK FUNCTION FROM XnatUtils IN dax:
+        #  get_good_cscans / has_resource / etc...
+        #  get_good_cassr / is_cassessor_good_type / etc...
+        #
+        # EXAMPLE:
+        #  if XnatUtils.is_cscan_unusable(cscan):
+        #      return -1, 'Scan unusable'
+        #
+        #  if XnatUtils.has_resource(cscan, 'NIFTI'):
+        #      return 1, None
+        #
+        #  LOGGER.debug('{name}: No NIFI found.')
+        #  return 0, 'No NIFTI'
+        #
+
+        return status, qcstatus
+
+    def get_cmds(self, assessor, jobdir):
+        '''
+        function to generate the spider command for cluster job
+
+        :param assessor: pyxnat assessor object
+        :param jobdir: jobdir where the job's output will be generated
+        :return: command to execute the spider in the job script
+        '''
+        proj_label = assessor.parent().parent().parent().label()
+        subj_label = assessor.parent().parent().label()
+        sess_label = assessor.parent().label()
+        assr_label = assessor.label()
+        scan_label = assr.split('-x-')[3]
+
+        #
+        # ADD CUSTOM PARAMETERS TO THE SPIDER TEMPLATE (don't forgot the SPIDER_FORMAT (top))
+        #
+
+        cmd = SPIDER_FORMAT.format(spider=self.spider_path,
+                                   spm=self.spm_path,
+                                   proj=proj_label,
+                                   subj=subj_label,
+                                   sess=sess_label,
+                                   scan=scan_label,
+                                   dir=jobdir,
+                                   suffix_proc=self.suffix_proc)
+
+        return [cmd]
+"""
+
+SESSION_LEVEL_TEMPLATE = DEFAULT_TEMPLATE+"""
+# Format for the spider command line
+SPIDER_FORMAT = '''python {{spider}} -v --spm {{spm}} \
+-p {{proj}} -s {{subj}} -e {{sess}} -d {{dir}} --suffix "{{suffix_proc}}"'''
+
+class {name}_Processor(SessionProcessor):
+    '''
+    Processor class for {name} that runs on a session
+
+    :param spider_path: spider path on the system
+    :param version: version of the spider
+    :param walltime: walltime required by the spider
+    :param mem_mb: memory in Mb required by the spider
+    :param scan_types: scan types on XNAT that the spider should run on
+    :param spm_path: path to SPM
+    #
+    # ADD MORE PARAMETERS AS NEEDED HERE
+    #
+    :param suffix: suffix to the spider
+    '''
+    def __init__(self, spider_path=DEFAULT_SPIDER_PATH, version=None,
+                 walltime=DEFAULT_WALLTIME, mem_mb=DEFAULT_MEM,
+                 spm_path=PathSettings.SPM_PATH, suffix_proc=''):
+        super({name}_Processor, self).__init__(walltime, mem_mb, spider_path, version,
+                                               suffix_proc=suffix_proc)
+        self.spm_path = spm_path
+        #
+        # ADD MORE PARAMETERS AS NEEDED HERE LIKE self.param = param
+        #
+
+    def has_inputs(self, csess):
+        '''
+        function overridden from base class
+        By definition, status = 0 if still NEED_INPUTS, -1 if NO_DATA, 1 if NEED_TO_RUN
+                       qcstatus needs a value only when -1 or 0.
+        You can set qcstatus to a short string that explain why it's no ready to run.
+            e.g: No NIFTI
+
+        :param csess: object csess define in dax.XnatUtils (see XnatUtils in dax for information)
+        :return: status, qcstatus
+        '''
+        #
+        # CODE TO CHECK IF THE PROCESS HAS THE INPUTS NEEDED FROM XNAT
+        # CHECK FUNCTION FROM XnatUtils IN dax:
+        #  get_good_cscans / has_resource / etc...
+        #  get_good_cassr / is_cassessor_good_type / etc...
+        #
+
+        return status, qcstatus
+
+    def get_cmds(self, assessor, jobdir):
+        '''
+        function to generate the spider command for cluster job
+
+        :param assessor: pyxnat assessor object
+        :param jobdir: jobdir where the job's output will be generated
+        :return: command to execute the spider in the job script
+        '''
+        proj_label = assessor.parent().parent().parent().label()
+        subj_label = assessor.parent().parent().label()
+        sess_label = assessor.parent().label()
+
+        #
+        # ADD CUSTOM PARAMETERS TO THE SPIDER TEMPLATE (don't forgot the SPIDER_FORMAT (top))
+        #
+
+        cmd = SPIDER_FORMAT.format(spider=self.spider_path,
+                                   proj=proj_label,
+                                   subj=subj_label,
+                                   sess=sess_label,
+                                   spm=self.spm_path,
+                                   dir=jobdir)
+
+        return [cmd]
+"""
+
+def write_processor(processor_fpath, templates, args):
+    """
+    Write the Processor.py with the proper template
+
+    :param processor_fpath: path where the processor script will be saved
+    :param templates: template to use (scan or session)
+    :param args: arguments parser
+    """
+    processor_code = templates.format(author=args.author,
+                                      email_addr=args.email,
+                                      name=args.name,
+                                      now=str(datetime.now()),
+                                      purpose=args.purpose)
+    f_obj = open(processor_fpath, "w")
+    f_obj.writelines(processor_code)
+    f_obj.close()
+
+def parse_args():
+    """
+    Parser for arguments
+    """
+    from argparse import ArgumentParser
+    usage = "Generate a processor.py file from the template for dax in a new file."
+    argp = ArgumentParser(prog='GenerateProcessorTemplate', description=usage)
+    argp.add_argument('-n', dest='name', help='Name for Processor. E.G: fMRIQA.', required=True)
+    argp.add_argument('-a', dest='author', help='Author name.', required=True)
+    argp.add_argument('-e', dest='email', help='Author email address.', required=True)
+    argp.add_argument('-p', dest='purpose', help='Processor purpose.', required=True)
+    argp.add_argument('--onScan', dest='on_scan', action='store_true', help='Use Scan type Spider.')
+    argp.add_argument('-d', dest='directory',
+                      help='Directory where the processor file will be generated. Default: current directory.', default=None)
+    return argp.parse_args()
+
+if __name__ == '__main__':
+    ARGS = parse_args()
+
+    # Removing Spider if present in name
+    if "processor" in ARGS.name.lower():
+        ERR = "wrong name for the processor. Remove 'processor' from the name"
+        raise ValueError(ERR)
+
+    PROCESSOR_NAME = """Processor_{name}.py""".format(name=ARGS.name)
+    if ARGS.directory and os.path.exists(ARGS.directory):
+        PROCESSOR_FPATH = os.path.join(ARGS.directory, PROCESSOR_NAME)
+    else:
+        PROCESSOR_FPATH = os.path.join(os.getcwd(), PROCESSOR_NAME)
+    if ARGS.on_scan:
+        print "Generating file %s for scan processor %s ..." % (PROCESSOR_FPATH, ARGS.name)
+        write_processor(PROCESSOR_FPATH, SCAN_LEVEL_TEMPLATE, ARGS)
+    else:
+        print "Generating file %s for session processor %s ..." % (PROCESSOR_FPATH, ARGS.name)
+        write_processor(PROCESSOR_FPATH, SESSION_LEVEL_TEMPLATE, ARGS)

--- a/dax/XnatUtils.py
+++ b/dax/XnatUtils.py
@@ -152,11 +152,8 @@ class SpiderProcessHandler:
         if suffix:
             if suffix[0] !='_': #check that it starts with an underscore
                 suffix = '_'+suffix
-            suffix = suffix.strip().replace(" ","")\
-                                   .replace('/','_').replace('*','_')\
-                                   .replace('.','_').replace(',','_')\
-                                   .replace('?','_').replace('!','_')\
-                                   .replace(';','_').replace(':','_')
+            # suffix: remove any special characters and replace by '_'
+            suffix = re.sub('[^a-zA-Z0-9]', '_', suffix)
             proctype = proctype + suffix
 
         #Create the assessor handler


### PR DESCRIPTION
Hi,

I create two executables to help the users to create Modules_name.py files and Processor_name.py files. Those executables are generators for modules/processors.

You can select --onScan if you want to generate a ScanModule or nothing for SessionModule (i.e Processor). It will generate a python file with the default template. You can then edit this file as you wish.

For the Processor version, I added : "from dax_spiders import PathSettings". I am working on dax_spiders package and I am adding a file PathSettings where the users will set all their paths for their spiders/processors/modules.

Best,

Ben