### PR TITLE
Adding two functions

### DIFF
--- a/dax/XnatUtils.py
+++ b/dax/XnatUtils.py
@@ -1348,8 +1348,8 @@ def is_assessor_on_same_session_usable(cobj, proctype, is_scan_proc=False):
 
 def is_assessor_same_scan_unusable(cscan, proctype):
     """
-    Check to see if the assessor matching the user passed scan and proctype has
-     passed QC.
+    Deprecated method to check to see if the assessor matching the user passed scan and proctype has
+     passed QC. (See is_assessor_on_same_session_usable)
 
     :param cscan: CachedImageScan object from XnatUtils
     :param proctype: Process type of the assessor

--- a/dax/XnatUtils.py
+++ b/dax/XnatUtils.py
@@ -1308,13 +1308,13 @@ def get_cassr_on_same_session(cobj, proctype, is_scan_proc=False):
     """
     obj_info = cobj.info()
     cassr_list = list()
-    if isinstance(cobj, 'CachedImageScan'):
+    if isinstance(cobj, CachedImageScan):
         if is_scan_proc:
             assr_label = '-x-'.join([obj_info['project_id'], obj_info['subject_label'], obj_info['session_label'], obj_info['ID'], proctype])
         else:
             assr_label = '-x-'.join([obj_info['project_id'], obj_info['subject_label'], obj_info['session_label'],  proctype])
         cassr_list = [cassr for cassr in cobj.parent().assessors() if cassr.info()['label'] == assr_label]
-    elif isinstance(cobj, 'CachedImageSession'):
+    elif isinstance(cobj, CachedImageSession):
         cassr_list = [cassr for cassr in cobj.assessors() if cassr.info()['proctype'] == proctype]
     return cassr_list
 


### PR DESCRIPTION
Hi guys,

I am just adding the two functions we talked with Steve in one of the issues raised earlier.

I am adding two functions:
1) get the list of cassr from a cobj (scan or session) where the proctype is the one requested by the user
2) Check if an assessor with a good QC is matching the user proctype on a session. (is_assessor_same_scan_unusable deprecated now since we can use this function instead) 

I haven't tested since I don't have this case here so far.
Let me know if something is missing.

Cheers,

Ben