### PR TITLE
Disk Q

### DIFF
--- a/bin/dax_tools/GenerateModuleTemplate
+++ b/bin/dax_tools/GenerateModuleTemplate
@@ -1,42 +1,45 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""
-    Title: GenerateModuleTemplate
-    Author: Benjamin Yvernault
-    contact: b.yvernault@ucl.ac.uk
-    Purpose:
-        Generate your module.py following the template for module describe in this file.
-"""
+"""Generator for Module templates.
 
-__author__ = 'Benjamin Yvernault'
-__email__ = 'b.yvernault@ucl.ac.uk'
-__purpose__ = "Generate your module.py following the template for module describe in this file."
-__version__ = '1.0.0'
-__modifications__ = '24 August 2015 - Original write'
+Title: GenerateModuleTemplate
+Author: Benjamin Yvernault
+contact: b.yvernault@ucl.ac.uk
+Purpose: Generate your module.py following the template for module
+         described in this file.
+"""
 
 import os
 import re
 from datetime import datetime
 
-DEFAULT_TEMPLATE = """'''
-    Author:         {author}
-    contact:        {email_addr}
-    Module name:    Module_{name}
-    Creation date:  {now}
-    Purpose:        {purpose}
-'''
+__author__ = 'Benjamin Yvernault'
+__email__ = 'b.yvernault@ucl.ac.uk'
+__purpose__ = "Generate your module.py following the template for \
+module describe in this file."
+__version__ = '1.0.0'
+__modifications__ = '24 August 2015 - Original write'
 
-__author__ = "{author}"
-__email__ = "{email_addr}"
-__purpose__ = "{purpose}"
-__module_name__ = "Module_{name}"
-__modifications__ = "{now} - Original write"
+DEFAULT_TEMPLATE = '''"""Module to do: {purpose}.
+
+Author:         {author}
+contact:        {email_addr}
+Module name:    Module_{name}
+Creation date:  {now}
+Purpose:        {purpose}
+"""
 
 # Python packages import
 import os
 import logging
 from dax import XnatUtils, ScanModule, SessionModule
+
+__author__ = "{author}"
+__email__ = "{email_addr}"
+__purpose__ = "{purpose}"
+__module_name__ = "Module_{name}"
+__modifications__ = """{now} - Original write"""
 
 # set-up logger for printing statements
 LOGGER = logging.getLogger('dax')
@@ -46,35 +49,41 @@ LOGGER = logging.getLogger('dax')
 DEFAULT_TPM_PATH = '/tmp/{name}_temp/'
 DEFAULT_MODULE_NAME = '{name}'
 DEFAULT_TEXT_REPORT = 'ERROR/WARNING for {name} :\\n'
-"""
+'''
 
-SCAN_LEVEL_TEMPLATE = DEFAULT_TEMPLATE+"""
+SCAN_LEVEL_TEMPLATE = DEFAULT_TEMPLATE + '''
+
 class Module_{name}(ScanModule):
-    '''
-    Module class for {name} that runs on a scan
+    """Module class for {name} that runs on a scan.
 
     :param mod_name: module name
     :param directory: temp directory for the module temporary files
     :param email: email address to send error/warning to
     :param text_report: title for the report
     #
-    # ADD MORE PARAMETERS AS NEEDED HERE
+    # ADD MORE PARAMETERS AS NEEDED HERE AND IN __INIT__
     #
-    '''
-    def __init__(self, mod_name=DEFAULT_MODULE_NAME, directory=DEFAULT_TPM_PATH, email=None,
+    """
+
+    def __init__(self, mod_name=DEFAULT_MODULE_NAME,
+                 directory=DEFAULT_TPM_PATH, email=None,
                  text_report=DEFAULT_TEXT_REPORT):
-        super(Module_{name}, self).__init__(mod_name, directory, email, text_report=text_report)
+        """Entry point for Module_{name} Class."""
+        super(Module_{name},
+              self).__init__(mod_name, directory, email,
+                             text_report=text_report)
         #
         # ADD MORE PARAMETERS AS NEEDED HERE LIKE self.param = param
         #
 
     def prerun(self, settings_filename=''):
-        '''
-        prerun function overridden from base-class
-        method that runs at the beginning, before looping over the sessions for the project
+        """Method overridden from base-class.
 
-        :param settings_filename: settings file name to set the temporary folder
-        '''
+        Method that runs at the beginning, before looping over the sessions
+        in a project on XNAT
+
+        :param settings_filename: settings filename to set the temporary folder
+        """
         # make temporary directory using the settings filename
         self.make_dir(settings_filename)
 
@@ -83,13 +92,14 @@ class Module_{name}(ScanModule):
         #
 
     def afterrun(self, xnat, project):
-        '''
-        afterrun function overridden from base-class
-        method that runs at the end, after looping over the sessions for the project
+        """Method overridden from base-class.
+
+        Method that runs at the end, after looping over the sessions
+        in a project on XNAT
 
         :param xnat: interface to xnat object (XnatUtils.get_interface())
         :param project: project ID/label on XNAT
-        '''
+        """
         #
         # ADD CODE HERE IF YOU NEED TO EXECUTE SOMETHING AFTER THE LOOP
         #
@@ -102,17 +112,19 @@ class Module_{name}(ScanModule):
         try:
             os.rmdir(self.directory)
         except:
-            LOGGER.warn('{name} -- afterrun -- '+self.directory+' not empty. Could not delete it.')
+            warn = '{name} -- afterrun -- %s not empty. Could not delete it.'
+            LOGGER.warn(warn % self.directory)
 
     def needs_run(self, cscan, xnat):
-        '''
-        needs_run function overridden from base-class
-        method that runs before each loop step to check if we need to run on this scan
+        """Method overridden from base-class.
+
+        Method that runs before each loop step to check
+        if we need to run on this scan
 
         :param cscan: CacheScan object from XnatUtils
         :param xnat: interface to xnat object (XnatUtils.get_interface())
         :return: boolean, True if needs to run
-        '''
+        """
         #
         # CODE TO CHECK IF THE MODULE NEEDS TO RUN FOR THE SCAN DEFINE BY CSCAN
         #
@@ -132,51 +144,58 @@ class Module_{name}(ScanModule):
         return True
 
     def run(self, scan_info, scan_obj):
-        '''
-        run method: {purpose}
-          lines of code that will be executed for the scan
+        """Method: {purpose}.
 
-        :param scan_info: python dictionary with information on the scan (see output of XnatUtils.list_scans)
+        Lines of code that will be executed for the scan
+
+        :param scan_info: python dictionary with information on the scan
+                          (see output of XnatUtils.list_scans)
         :param scan_obj: pyxnat Scan object
-        '''
+        """
         #
         # CODE TO EXECUTE ON THE SCAN (E.G: GENERATE NIFTI/PREVIEW)
         #
 
         # clean temporary folder
         self.clean_directory()
-"""
+'''
 
-SESSION_LEVEL_TEMPLATE = DEFAULT_TEMPLATE+"""
+SESSION_LEVEL_TEMPLATE = DEFAULT_TEMPLATE + '''
 # Resource name set on session to know that the module ran
 RESOURCE_FLAG_NAME = 'Module_{name}'
 
+
 class Module_{name}(SessionModule):
-    '''
-    Module class for {name} that runs on a session
+    """Module class for {name} that runs on a session.
 
     :param mod_name: module name
     :param directory: temp directory for the module temporary files
     :param email: email address to send error/warning to
     :param text_report: title for the report
     #
-    # ADD MORE PARAMETERS AS NEEDED HERE
+    # ADD MORE PARAMETERS AS NEEDED HERE AND IN __INIT__
     #
-    '''
-    def __init__(self, mod_name=DEFAULT_MODULE_NAME, directory=DEFAULT_TPM_PATH, email=None,
+    """
+
+    def __init__(self, mod_name=DEFAULT_MODULE_NAME,
+                 directory=DEFAULT_TPM_PATH, email=None,
                  text_report=DEFAULT_TEXT_REPORT):
-        super(Module_{name}, self).__init__(mod_name, directory, email, text_report=text_report)
+        """Entry point for Module_{name} Class."""
+        super(Module_{name},
+              self).__init__(mod_name, directory, email,
+                             text_report=text_report)
         #
         # ADD MORE PARAMETERS AS NEEDED HERE LIKE self.param = param
         #
 
     def prerun(self, settings_filename=''):
-        '''
-        prerun function overridden from base-class
-        method that runs at the beginning, before looping over the sessions for the project
+        """Method overridden from base-class.
 
-        :param settings_filename: settings file name to set the temporary folder
-        '''
+        Method that runs at the beginning, before looping over the sessions
+        in a project on XNAT
+
+        :param settings_filename: settings filename to set the temporary folder
+        """
         # make temporary directory using the settings filename
         self.make_dir(settings_filename)
 
@@ -185,13 +204,14 @@ class Module_{name}(SessionModule):
         #
 
     def afterrun(self, xnat, project):
-        '''
-        afterrun function overridden from base-class
-        method that runs at the end, after looping over the sessions for the project
+        """Method overridden from base-class.
+
+        Method that runs at the end, after looping over the sessions
+        in a project on XNAT
 
         :param xnat: interface to xnat object (XnatUtils.get_interface())
         :param project: project ID/label on XNAT
-        '''
+        """
         #
         # ADD CODE HERE IF YOU NEED TO EXECUTE SOMETHING AFTER THE LOOP
         #
@@ -204,31 +224,37 @@ class Module_{name}(SessionModule):
         try:
             os.rmdir(self.directory)
         except:
-            LOGGER.warn('{name} -- afterrun -- '+self.directory+' not empty. Could not delete it.')
+            warn = '{name} -- afterrun -- %s not empty. Could not delete it.'
+            LOGGER.warn(warn % self.directory)
 
     def needs_run(self, csess, xnat):
-        '''
-        needs_run function overridden from base-class
-        method that runs before each loop step to check if we need to run on this session
+        """Method overridden from base-class.
+
+        Method that runs before each loop step to check if we need to run
+        on this session
 
         :param csess: CacheSession object from XnatUtils
         :param xnat: interface to xnat object (XnatUtils.get_interface())
         :return: boolean, True if needs to run
-        '''
+        """
+
         #
-        # CODE TO CHECK IF THE MODULE NEEDS TO RUN FOR THE SESSION DEFINE BY CSESS
+        # CODE TO CHECK IF THE MODULE NEEDS TO RUN FOR THE SESSION DEFINE \
+BY CSESS
         # FOR SESSION MODULE, SET A RESOURCE ON SESSION WITH FLAG NAME
         #
+
         return self.has_flag_resource(csess, RESOURCE_FLAG_NAME)
 
     def run(self, session_info, session_obj):
-        '''
-        run method: {purpose}
-          lines of code that will be executed for the session
+        """Method: {purpose}.
 
-        :param session_info: python dictionary with information on the session (see output of XnatUtils.list_sessions)
+        Lines of code that will be executed for the session
+
+        :param session_info: python dictionary with information on the session
+                             (see output of XnatUtils.list_sessions)
         :param session_obj: pyxnat Session object
-        '''
+        """
         #
         # CODE TO EXECUTE ON THE SESSION (E.G: SET SCAN TYPE)
         #
@@ -238,11 +264,11 @@ class Module_{name}(SessionModule):
 
         # create the flag resource on the session
         session_obj.resource(RESOURCE_FLAG_NAME).create()
-"""
+'''
+
 
 def write_module(templates):
-    """
-    Write the Module.py with the proper template
+    """Write the Module.py with the proper template.
 
     :param templates: template to use (scan or session)
     :return: None
@@ -256,28 +282,33 @@ def write_module(templates):
     f_obj.writelines(module_code)
     f_obj.close()
 
+
 def parse_args():
-    """
-    Method to parse arguments base on ArgumentParser
+    """Method to parse arguments base on ArgumentParser.
 
     :return: parser object parsed
     """
     from argparse import ArgumentParser
-    usage = "Generate a module.py file from the template for dax in a new file."
-    argp = ArgumentParser(prog='GenerateModuleTemplate', description=usage)
-    argp.add_argument('-n', dest='name', help='Name for module. E.G: dcm2nii.', required=True)
+    argp = ArgumentParser(prog='GenerateModuleTemplate',
+                          description=__purpose__)
+    argp.add_argument('-n', dest='name', required=True,
+                      help='Name for module. E.G: dcm2nii.')
     argp.add_argument('-a', dest='author', help='Author name.', required=True)
-    argp.add_argument('-e', dest='email', help='Author email address.', required=True)
-    argp.add_argument('-p', dest='purpose', help='Module purpose.', required=True)
-    argp.add_argument('--onScan', dest='on_scan', action='store_true', help='Use Scan type Spider.')
-    argp.add_argument('-d', dest='directory',
-                      help='Directory where the module file will be generated. Default: current directory.', default=None)
+    argp.add_argument('-e', dest='email', required=True,
+                      help='Author email address.')
+    argp.add_argument('-p', dest='purpose', required=True,
+                      help='Module purpose.')
+    argp.add_argument('--onScan', dest='on_scan', action='store_true',
+                      help='Use Scan type Spider.')
+    argp.add_argument('-d', dest='directory', default=None,
+                      help='Directory where the module file will be generated. \
+Default: current directory.')
     return argp.parse_args()
 
 if __name__ == '__main__':
     ARGS = parse_args()
 
-    ## Get a proper name from the input
+    # Get a proper name from the input
     # remove .py if present at the end of the file
     if ARGS.name.endswith('.py'):
         ARGS.name = ARGS.name[:-3]
@@ -296,8 +327,10 @@ if __name__ == '__main__':
     else:
         MODULE_FPATH = os.path.join(os.getcwd(), MODULE_NAME)
     if ARGS.on_scan:
-        print "Generating file %s for scan module %s ..." % (MODULE_FPATH, ARGS.name)
+        print "Generating file %s for scan module %s ..." % \
+              (MODULE_FPATH, ARGS.name)
         write_module(SCAN_LEVEL_TEMPLATE)
     else:
-        print "Generating file %s for session module %s ..." % (MODULE_FPATH, ARGS.name)
+        print "Generating file %s for session module %s ..." % \
+              (MODULE_FPATH, ARGS.name)
         write_module(SESSION_LEVEL_TEMPLATE)

--- a/bin/dax_tools/GenerateProcessorTemplate
+++ b/bin/dax_tools/GenerateProcessorTemplate
@@ -1,42 +1,45 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""
-    Title: GenerateProcessorTemplate
-    Author: Benjamin Yvernault
-    contact: b.yvernault@ucl.ac.uk
-    Purpose:
-        Generate your processor.py following the template for processor describe in this file.
-"""
+"""Generator for Processor templates.
 
-__author__ = 'Benjamin Yvernault'
-__email__ = 'b.yvernault@ucl.ac.uk'
-__purpose__ = "Generate your processor.py following the template for processor describe in this file."
-__version__ = '1.0.0'
-__modifications__ = '24 August 2015 - Original write'
+Title: GenerateProcessorTemplate
+Author: Benjamin Yvernault
+contact: b.yvernault@ucl.ac.uk
+Purpose: Generate your processor.py following the template for processor
+         described in this file.
+"""
 
 import os
 import re
 from datetime import datetime
 
-DEFAULT_TEMPLATE = """'''
-    Author:         {author}
-    contact:        {email_addr}
-    Processor name: Processor_{name}
-    Creation date:  {now}
-    Purpose:        {purpose}
-'''
+__author__ = 'Benjamin Yvernault'
+__email__ = 'b.yvernault@ucl.ac.uk'
+__purpose__ = "Generate your processor.py following the template for processor\
+described in this file."
+__version__ = '1.0.0'
+__modifications__ = '24 August 2015 - Original write'
 
-__author__ = "{author}"
-__email__ = "{email_addr}"
-__purpose__ = "{purpose}"
-__processor_name__ = "Processor_{name}"
-__modifications__ = "{now} - Original write"
+DEFAULT_TEMPLATE = '''"""Processor associated to Spider_{name}.
+
+Author:         {author}
+contact:        {email_addr}
+Processor name: Processor_{name}
+Creation date:  {now}
+Purpose:        {purpose}
+"""
 
 # Python packages import
 import os
 import logging
 from dax import XnatUtils, ScanProcessor, SessionProcessor
+
+__author__ = "{author}"
+__email__ = "{email_addr}"
+__purpose__ = "{purpose}"
+__processor_name__ = "Processor_{name}"
+__modifications__ = """{now} - Original write"""
 
 # set-up logger for printing statements
 LOGGER = logging.getLogger('dax')
@@ -46,18 +49,24 @@ LOGGER = logging.getLogger('dax')
 DEFAULT_SPIDER_PATH = os.path.join(SPIDER_PATH, 'Spider_{name}_v1_0_0.py')
 DEFAULT_WALLTIME = '01:00:00'
 DEFAULT_MEM = 2048
-"""
+'''
 
-SCAN_LEVEL_TEMPLATE = DEFAULT_TEMPLATE+"""
+SCAN_LEVEL_TEMPLATE = DEFAULT_TEMPLATE + '''
 DEFAULT_SCAN_TYPES = [] # ADD SCAN TYPES
 
 # Format for the spider command line
-SPIDER_FORMAT = '''python {{spider}} -p {{proj}} -s {{subj}} -e {{sess}} -c {{scan}} \
--d {{dir}} --suffix "{{suffix_proc}}"'''
+SPIDER_FORMAT = """python {{spider}} \\
+-p {{proj}} \\
+-s {{subj}} \\
+-e {{sess}} \\
+-c {{scan}} \\
+-d {{dir}} \\
+--suffix "{{suffix_proc}}"
+"""
+
 
 class Processor_{name}(ScanProcessor):
-    '''
-    Processor class for {name} that runs on a scan
+    """Processor class for {name} that runs on a scan.
 
     :param spider_path: spider path on the system
     :param version: version of the spider
@@ -66,31 +75,38 @@ class Processor_{name}(ScanProcessor):
     :param scan_types: scan types on XNAT that the spider should run on
 
     #
-    # ADD MORE PARAMETERS AS NEEDED HERE
+    # ADD MORE PARAMETERS AS NEEDED HERE AND IN __INIT__
     #
 
     :param suffix: suffix to the spider
-    '''
+    """
+
     def __init__(self, spider_path=DEFAULT_SPIDER_PATH, version=None,
                  walltime=DEFAULT_WALLTIME, mem_mb=DEFAULT_MEM,
                  scan_types=DEFAULT_SCAN_TYPES, suffix_proc=''):
-        super(Processor_{name}, self).__init__(scan_types, walltime, mem_mb, spider_path,
-                                               version, suffix_proc=suffix_proc)
+        """Entry point for Processor_{name} Class."""
+        super(Processor_{name},
+              self).__init__(scan_types, walltime, mem_mb, spider_path,
+                             version, suffix_proc=suffix_proc)
         #
         # ADD MORE PARAMETERS AS NEEDED HERE LIKE self.param = param
         #
 
     def has_inputs(self, cscan):
-        '''
-        function overridden from base class
-        By definition, status = 0 if still NEED_INPUTS, -1 if NO_DATA, 1 if NEED_TO_RUN
-                       qcstatus needs a value only when -1 or 0.
-        You can set qcstatus to a short string that explain why it's no ready to run.
-            e.g: No NIFTI
+        """Method overridden from base class.
 
-        :param cscan: object cscan define in dax.XnatUtils (see XnatUtils in dax for information)
+        By definition:
+            status = 0  -> NEED_INPUTS,
+            status = 1  -> NEED_TO_RUN
+            status = -1 -> NO_DATA
+            qcstatus needs a value only when -1 or 0.
+        You need to set qcstatus to a short string that explain
+        why it's no ready to run. e.g: No NIFTI
+
+        :param cscan: object cscan define in dax.XnatUtils
+                      (see XnatUtils in dax for information)
         :return: status, qcstatus
-        '''
+        """
 
         #
         # CODE TO CHECK IF THE PROCESS HAS THE INPUTS NEEDED FROM XNAT
@@ -112,13 +128,12 @@ class Processor_{name}(ScanProcessor):
         return status, qcstatus
 
     def get_cmds(self, assessor, jobdir):
-        '''
-        function to generate the spider command for cluster job
+        """Method to generate the spider command for cluster job.
 
         :param assessor: pyxnat assessor object
         :param jobdir: jobdir where the job's output will be generated
         :return: command to execute the spider in the job script
-        '''
+        """
         proj_label = assessor.parent().parent().parent().label()
         subj_label = assessor.parent().parent().label()
         sess_label = assessor.parent().label()
@@ -126,7 +141,8 @@ class Processor_{name}(ScanProcessor):
         scan_label = assr_label.split('-x-')[3]
 
         #
-        # ADD CUSTOM PARAMETERS TO THE SPIDER TEMPLATE (don't forgot the SPIDER_FORMAT (top))
+        # ADD CUSTOM PARAMETERS TO THE SPIDER TEMPLATE \
+(don't forgot the SPIDER_FORMAT (top))
         #
 
         cmd = SPIDER_FORMAT.format(spider=self.spider_path,
@@ -138,46 +154,58 @@ class Processor_{name}(ScanProcessor):
                                    suffix_proc=self.suffix_proc)
 
         return [cmd]
+'''
+
+SESSION_LEVEL_TEMPLATE = DEFAULT_TEMPLATE + '''
+# Format for the spider command line
+SPIDER_FORMAT = """python {{spider}} \\
+-p {{proj}} \\
+-s {{subj}} \\
+-e {{sess}} \\
+-d {{dir}} \\
+--suffix "{{suffix_proc}}"
 """
 
-SESSION_LEVEL_TEMPLATE = DEFAULT_TEMPLATE+"""
-# Format for the spider command line
-SPIDER_FORMAT = '''python {{spider}} -p {{proj}} -s {{subj}} -e {{sess}} \
--d {{dir}} --suffix "{{suffix_proc}}"'''
 
 class Processor_{name}(SessionProcessor):
-    '''
-    Processor class for {name} that runs on a session
+    """Processor class for {name} that runs on a session.
 
     :param spider_path: spider path on the system
     :param version: version of the spider
     :param walltime: walltime required by the spider
     :param mem_mb: memory in Mb required by the spider
     #
-    # ADD MORE PARAMETERS AS NEEDED HERE
+    # ADD MORE PARAMETERS AS NEEDED HERE AND IN THE __INIT__
     #
     :param suffix: suffix to the spider
-    '''
+    """
+
     def __init__(self, spider_path=DEFAULT_SPIDER_PATH, version=None,
                  walltime=DEFAULT_WALLTIME, mem_mb=DEFAULT_MEM,
                  suffix_proc=''):
-        super(Processor_{name}, self).__init__(walltime, mem_mb, spider_path, version,
-                                               suffix_proc=suffix_proc)
+        """Entry point for Processor_{name} Class."""
+        super(Processor_{name},
+              self).__init__(walltime, mem_mb, spider_path, version,
+                             suffix_proc=suffix_proc)
         #
         # ADD MORE PARAMETERS AS NEEDED HERE LIKE self.param = param
         #
 
     def has_inputs(self, csess):
-        '''
-        function overridden from base class
-        By definition, status = 0 if still NEED_INPUTS, -1 if NO_DATA, 1 if NEED_TO_RUN
-                       qcstatus needs a value only when -1 or 0.
-        You can set qcstatus to a short string that explain why it's no ready to run.
-            e.g: No NIFTI
+        """Method overridden from base class.
 
-        :param csess: object csess define in dax.XnatUtils (see XnatUtils in dax for information)
+        By definition:
+            status = 0  -> NEED_INPUTS,
+            status = 1  -> NEED_TO_RUN
+            status = -1 -> NO_DATA
+            qcstatus needs a value only when -1 or 0.
+        You need to set qcstatus to a short string that explain
+        why it's no ready to run. e.g: No NIFTI
+
+        :param csess: object csess define in dax.XnatUtils
+                      (see XnatUtils in dax for information)
         :return: status, qcstatus
-        '''
+        """
 
         #
         # CODE TO CHECK IF THE PROCESS HAS THE INPUTS NEEDED FROM XNAT
@@ -189,19 +217,19 @@ class Processor_{name}(SessionProcessor):
         return status, qcstatus
 
     def get_cmds(self, assessor, jobdir):
-        '''
-        function to generate the spider command for cluster job
+        """Method to generate the spider command for cluster job.
 
         :param assessor: pyxnat assessor object
         :param jobdir: jobdir where the job's output will be generated
         :return: command to execute the spider in the job script
-        '''
+        """
         proj_label = assessor.parent().parent().parent().label()
         subj_label = assessor.parent().parent().label()
         sess_label = assessor.parent().label()
 
         #
-        # ADD CUSTOM PARAMETERS TO THE SPIDER TEMPLATE (don't forgot the SPIDER_FORMAT (top))
+        # ADD CUSTOM PARAMETERS TO THE SPIDER TEMPLATE \
+(don't forgot the SPIDER_FORMAT (top))
         #
 
         cmd = SPIDER_FORMAT.format(spider=self.spider_path,
@@ -211,11 +239,11 @@ class Processor_{name}(SessionProcessor):
                                    dir=jobdir)
 
         return [cmd]
-"""
+'''
+
 
 def write_processor(templates):
-    """
-    Write the Processor.py with the proper template
+    """Write the Processor.py with the proper template.
 
     :param processor_fpath: path where the processor script will be saved
     :param templates: template to use (scan or session)
@@ -230,28 +258,34 @@ def write_processor(templates):
     f_obj.writelines(processor_code)
     f_obj.close()
 
+
 def parse_args():
-    """
-    Method to parse arguments base on ArgumentParser
+    """Method to parse arguments base on ArgumentParser.
 
     :return: parser object parsed
     """
     from argparse import ArgumentParser
-    usage = "Generate a processor.py file from the template for dax in a new file."
-    argp = ArgumentParser(prog='GenerateProcessorTemplate', description=usage)
-    argp.add_argument('-n', dest='name', help='Name for Processor. E.G: fMRIQA.', required=True)
-    argp.add_argument('-a', dest='author', help='Author name.', required=True)
-    argp.add_argument('-e', dest='email', help='Author email address.', required=True)
-    argp.add_argument('-p', dest='purpose', help='Processor purpose.', required=True)
-    argp.add_argument('--onScan', dest='on_scan', action='store_true', help='Use Scan type Spider.')
-    argp.add_argument('-d', dest='directory',
-                      help='Directory where the processor file will be generated. Default: current directory.', default=None)
+    argp = ArgumentParser(prog='GenerateProcessorTemplate',
+                          description=__purpose__)
+    argp.add_argument('-n', dest='name', required=True,
+                      help='Name for Processor. E.G: fMRIQA.')
+    argp.add_argument('-a', dest='author', required=True, help='Author name.')
+    argp.add_argument('-e', dest='email', required=True,
+                      help='Author email address.')
+    argp.add_argument('-p', dest='purpose', required=True,
+                      help='Processor purpose.')
+    argp.add_argument('--onScan', dest='on_scan', action='store_true',
+                      help='Use Scan type Spider.')
+    argp.add_argument('-d', dest='directory', default=None,
+                      help='Directory where the processor file will be \
+generated. Default: current directory.')
     return argp.parse_args()
+
 
 if __name__ == '__main__':
     ARGS = parse_args()
 
-    ## Get a proper name from the input
+    # Get a proper name from the input
     # remove .py if present at the end of the file
     if ARGS.name.endswith('.py'):
         ARGS.name = ARGS.name[:-3]
@@ -270,8 +304,10 @@ if __name__ == '__main__':
     else:
         PROCESSOR_FPATH = os.path.join(os.getcwd(), PROCESSOR_NAME)
     if ARGS.on_scan:
-        print "Generating file %s for scan processor %s ..." % (PROCESSOR_FPATH, ARGS.name)
+        print "Generating file %s for scan processor %s ..." % \
+              (PROCESSOR_FPATH, ARGS.name)
         write_processor(SCAN_LEVEL_TEMPLATE)
     else:
-        print "Generating file %s for session processor %s ..." % (PROCESSOR_FPATH, ARGS.name)
+        print "Generating file %s for session processor %s ..." % \
+              (PROCESSOR_FPATH, ARGS.name)
         write_processor(SESSION_LEVEL_TEMPLATE)

--- a/bin/dax_tools/GenerateSettingsTemplate
+++ b/bin/dax_tools/GenerateSettingsTemplate
@@ -1,104 +1,116 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""
-    Title: GenerateSettingsTemplate
-    Author: Benjamin Yvernault
-    contact: b.yvernault@ucl.ac.uk
-    Purpose:
-        Generate your ProjectSettingsFile.py following the template describe in this file.
-"""
+"""Generator for Settings File.
 
-__author__ = 'Benjamin Yvernault'
-__email__ = 'b.yvernault@ucl.ac.uk'
-__purpose__ = 'Generate your ProjectSettingsFile.py following the template describe in this file.'
-__version__ = '1.0.0'
-__modifications__ = '29 Septembre 2015 - Original write'
+Title: GenerateSettingsTemplate
+Author: Benjamin Yvernault
+contact: b.yvernault@ucl.ac.uk
+Purpose: Generate your ProjectSettingsFile.py following the template described
+         in this file.
+"""
 
 import os
 import re
 from datetime import datetime
 from dax import DAX_Settings
 
+__author__ = 'Benjamin Yvernault'
+__email__ = 'b.yvernault@ucl.ac.uk'
+__purpose__ = 'Generate your ProjectSettingsFile.py following the template \
+described in this file.'
+__version__ = '1.0.0'
+__modifications__ = '29 Septembre 2015 - Original write'
+
 DAX_SETTINGS = DAX_Settings()
 DEFAULT_EMAIL_OPTS = DAX_SETTINGS.get_email_opts()
 DEFAULT_QUEUE_LIMIT = DAX_SETTINGS.get_queue_limit()
 
-DEFAULT_TEMPLATE = """'''
-    Author:                     {author}
-    contact:                    {email_addr}
-    Project Settings File name: {name}
-    Creation date:              {now}
-    Purpose:                    Settings file to describe the modules/processors for the project(s)
-'''
+DEFAULT_TEMPLATE = '''"""Settings_{name}.
 
-## header:
+Author: {author}
+contact: {email_addr}
+Settings File name: {name}
+Creation date: {now}
+Purpose: Settings file to describe the modules/processors for the project(s)
+"""
+
+# Python packages import:
+from dax import Launcher
+
+# header:
 __author__ = "{author}"
 __email__ = "{email_addr}"
-__purpose__ = "Settings file to describe the modules/processors for the project(s)"
-__processor_name__ = "{name}"
+__purpose__ = "Settings file to describe the modules/processors for \\
+the project(s)"
+__settings_name__ = "{name}"
 __modifications__ = "{now} - Original write"
 
-## Python packages import:
-import os
-from dax import Launcher
-from Xnat_process_importer import *
-from Xnat_module_importer import *
-
-## Arguments for Launcher:
+# Arguments for Launcher:
 EMAIL = "{email_addr}"
 QUEUE_LIMIT = {q_limit}
 PRIORITY_ORDER = {p_order}  # CHANGE THE ORDER OF PRIORITY FOR YOUR PROJECT(S)
-EMAIL_OPTS = {e_opts}
+EMAIL_OPTS = "{e_opts}"
+XNAT_HOST = "{host}"
 
-## Modules
+# Modules
 
 #
 # DEFINE THE MODULES YOU WANT TO RUN FOR YOUR PROJECT(S).
 # E.G: VUSTP_Module_dcm2nii = Module_dcm2nii(directory="/tmp/dcm2nii_phillips")
 #
 
-## Processors
+# Processors
 
 #
 # DEFINE THE PROCESSORS YOU WANT TO RUN FOR YOUR PROJECT(S).
-# E.G: VUSTP_1_Processor_fMRIQA = Processor_fMRIQA(mem_mb="4096",version="2.0.0")
+# E.G: VUSTP_1_Processor_fMRIQA = Processor_fMRIQA(mem_mb="4096", \
+version="2.0.0")
 #
 
-## Associate Project with modules/processors
+# Associate Project with modules/processors
 # modules
 # ADD THE MODULES FOR EACH PROJECT OR LEAVE IT EMPTY
 proj_mod = {p_mod}
 
-#processors
+# processors
 # ADD THE PROCESSORS FOR EACH PROJECT OR LEAVE IT EMPTY
 proj_proc = {p_proc}
 
-## Launcher
+# Launcher
 myLauncher = Launcher(proj_proc, proj_mod, priority_project=PRIORITY_ORDER,
                       job_email=EMAIL, job_email_options=EMAIL_OPTS,
-                      queue_limit=QUEUE_LIMIT)
+                      queue_limit=QUEUE_LIMIT, xnat_host=XNAT_HOST)
+'''
 
-"""
 
 def write_settings():
-    """
-    Write the ProjectSettingsFile.py from the template
+    """Write the ProjectSettingsFile.py from the template.
 
     :return: None
     """
-    priority = ARGS.p_order.split(",")
-    p_mod = '{'
-    p_proc = '{'
-    for ind,  project in enumerate(priority):
-        if ind != 0:
-            p_mod += ' '*12+'"'+project+'": [],\n' # 12 = length of proj_mod = {
-            p_proc += ' '*13+'"'+project+'": [],\n' # 13 = length of proj_proc = {
-        else:
-            p_mod += '"'+project+'": [],\n' # 12 = length of proj_mod = {
-            p_proc += '"'+project+'": [],\n' # 13 = length of proj_proc = {
-    p_mod = p_mod[:-2]+'}'
-    p_proc = p_proc[:-2]+'}'
+    priority = []
+    host = '%s' % ARGS.xnat_host if ARGS.xnat_host else ''
+    if ARGS.p_order:
+        priority = ARGS.p_order.split(",")
+        p_mod = '{'
+        p_proc = '{'
+        for ind,  project in enumerate(priority):
+            if ind == 0:
+                p_mod += '"%s": [],\n' % project
+                p_proc += '"%s": [],\n' % project
+            else:
+                # 12 = length of proj_mod = {
+                p_mod += '%s"%s": [],\n' % (' '*12, project)
+                # 13 = length of proj_proc = {
+                p_proc += '%s"%s": [],\n' % (' '*13, project)
+        p_mod = p_mod[:-2] + '}'
+        p_proc = p_proc[:-2] + '}'
+    else:
+        p_mod = '{"proj1": ["module1", "...", "moduleN"], \
+"proj2": ["module1", "...", "moduleN"]}'
+        p_proc = '{"proj1": ["processor1", "...", "processorN"], \
+"proj2": ["processor1", "...", "processorN"]}'
 
     settings_code = DEFAULT_TEMPLATE.format(author=ARGS.author,
                                             email_addr=ARGS.email,
@@ -108,35 +120,45 @@ def write_settings():
                                             p_order=priority,
                                             e_opts=ARGS.e_opts,
                                             p_mod=p_mod,
-                                            p_proc=p_proc)
+                                            p_proc=p_proc,
+                                            host=host)
     f_obj = open(SETTINGS_FPATH, "w")
     f_obj.writelines(settings_code)
     f_obj.close()
 
+
 def parse_args():
-    """
-    Method to parse arguments base on ArgumentParser
+    """Method to parse arguments base on ArgumentParser.
 
     :return: parser object parsed
     """
     from argparse import ArgumentParser
-    usage = "Generate a ProjectSettingsFile.py file from the dax template for settings file."
-    argp = ArgumentParser(prog='GenerateSettingsTemplate', description=usage)
-    argp.add_argument('-n', dest='name', help='Name for ProjectSettingsFile.', required=True)
-    argp.add_argument('-a', dest='author', help='Author name.', required=True)
-    argp.add_argument('-e', dest='email', help='Author email address.', required=True)
-    argp.add_argument('-p', dest='p_order', help='Projects to process in order separate by a coma. E.G: ADNI,Test,Project3', required=True)
-    argp.add_argument('--Qlimit', dest='q_limit', help='Queue limit on cluster to submit jobs. Default: %s' % str(DEFAULT_QUEUE_LIMIT),
-                      default=DEFAULT_QUEUE_LIMIT)
-    argp.add_argument('--Eopts', dest='e_opts', help='Options for email in the job. Default= %s' % (DEFAULT_EMAIL_OPTS),
-                      default=DEFAULT_EMAIL_OPTS)
-    argp.add_argument('-d', dest='directory', help='Directory where the processor file will be generated. Default: current directory.', default=None)
+    argp = ArgumentParser(prog='GenerateSettingsTemplate',
+                          description=__purpose__)
+    argp.add_argument('-n', dest='name', required=True,
+                      help='Name for ProjectSettingsFile.')
+    argp.add_argument('-a', dest='author', required=True, help='Author name.')
+    argp.add_argument('-e', dest='email', required=True,
+                      help='Author email address.')
+    argp.add_argument('-p', dest='p_order', help='Projects to process in order \
+separate by a coma. E.G: ADNI,Test,Project3')
+    argp.add_argument('--Qlimit', dest='q_limit', default=DEFAULT_QUEUE_LIMIT,
+                      help='Queue limit on cluster to submit jobs. Default: %s'
+                      % str(DEFAULT_QUEUE_LIMIT))
+    argp.add_argument('--Eopts', dest='e_opts', default=DEFAULT_EMAIL_OPTS,
+                      help='Options for email in the job. Default= %s'
+                      % (DEFAULT_EMAIL_OPTS))
+    argp.add_argument('-d', dest='directory', default=None,
+                      help='Directory where the processor file will be \
+generated. Default: current directory.')
+    argp.add_argument('--host', dest='xnat_host', default=None,
+                      help='XNAT Host to run the settings on.')
     return argp.parse_args()
 
 if __name__ == '__main__':
     ARGS = parse_args()
 
-    ## Get a proper name from the input
+    # Get a proper name from the input
     # remove .py if present at the end of the file
     if ARGS.name.endswith('.py'):
         ARGS.name = ARGS.name[:-3]
@@ -148,6 +170,10 @@ if __name__ == '__main__':
     ARGS.name = re.sub('[^a-zA-Z0-9]', '_', ARGS.name)
     if ARGS.name[-1] == '_':
         ARGS.name = ARGS.name[:-1]
+    # Check email:
+    if ARGS.email and '@' not in ARGS.email and \
+       not len(ARGS.email.split('.')) > 1:
+        raise Exception("Error: email address not valid.")
 
     SETTINGS_NAME = """Settings_{name}.py""".format(name=ARGS.name)
     if ARGS.directory and os.path.exists(ARGS.directory):
@@ -155,5 +181,6 @@ if __name__ == '__main__':
     else:
         SETTINGS_FPATH = os.path.join(os.getcwd(), SETTINGS_NAME)
 
-    print "Generating file %s for scan processor %s ..." % (SETTINGS_FPATH, ARGS.name)
+    print "Generating file %s for scan processor %s ..." % \
+          (SETTINGS_FPATH, ARGS.name)
     write_settings()

--- a/bin/dax_tools/GenerateSpiderTemplate
+++ b/bin/dax_tools/GenerateSpiderTemplate
@@ -1,52 +1,55 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""
-    Title: generate_spider_template.py
-    Author: Benjamin Yvernault
-    contact: b.yvernault@ucl.ac.uk
-    Purpose:
-        Generate your Spider.py following the template for spider describe in this file.
-"""
+"""Generator for Spider templates.
 
-__author__ = 'Benjamin Yvernault'
-__email__ = 'b.yvernault@ucl.ac.uk'
-__purpose__ = "Generate your Spider.py following the template for spider describe in this file."
-__version__ = '1.0.0'
-__modifications__ = '21 August 2015 - Original write'
+Title: generate_spider_template.py
+Author: Benjamin Yvernault
+contact: b.yvernault@ucl.ac.uk
+Purpose: Generate your Spider.py following the template for spider describe
+         in this file.
+"""
 
 import os
 import re
 from dax import spiders
 from datetime import datetime
 
-DEFAULT_TEMPLATE = """'''
-    Author:         {author}
-    contact:        {email_addr}
-    Spider name:    {name}
-    Spider version: {version}
-    Creation date:  {now}
-    Purpose:        {purpose}
-'''
+__author__ = 'Benjamin Yvernault'
+__email__ = 'b.yvernault@ucl.ac.uk'
+__purpose__ = "Generate your Spider.py following the template for spider\
+describe in this file."
+__version__ = '1.0.0'
+__modifications__ = '21 August 2015 - Original write'
+
+DEFAULT_TEMPLATE = '''"""Spider_{name}.
+
+Author:         {author}
+contact:        {email_addr}
+Spider name:    {name}
+Spider version: {version}
+Creation date:  {now}
+Purpose:        {purpose}
+"""
+
+# Python packages import
+import os
+import sys
+from dax import XnatUtils, spiders, ScanSpider, SessionSpider
 
 __author__ = "{author}"
 __email__ = "{email_addr}"
 __purpose__ = "{purpose}"
 __spider_name__ = "{name}"
 __version__ = "{version}"
-__modifications__ = "{now} - Original write"
+__modifications__ = """{now} - Original write"""
 
-# Python packages import
-import os
-import sys
-from datetime import datetime
-from dax import XnatUtils, spiders, RESULTS_DIR, ScanSpider, SessionSpider
-"""
+'''
 
-SCAN_LEVEL_TEMPLATE = DEFAULT_TEMPLATE+"""
+SCAN_LEVEL_TEMPLATE = DEFAULT_TEMPLATE + '''
 def parse_args():
-    '''
-    Argument parser for the spider input variables
+    """Argument parser for the spider input variables.
+
     by default (set in get_session_argparser):
         -p       : proj_label
         -s       : subj_label
@@ -60,46 +63,56 @@ def parse_args():
         ...
 
     :return: argument parser object created by parse_args()
-    '''
-    from argparse import ArgumentParser
+    """
     ap = spiders.get_scan_argparser("{name}", "{purpose}")
 
     #
     # ADD YOUR OTHER OPTIONS FOR THIS SPECIFIC SPIDER
     # example to add one options:
-    # ap.add_argument("--option", dest="option_id", default=None, help="Option description.", required=True)
+    # ap.add_argument("--option", dest="option_id", default=None, \
+help="Option description.", required=True)
     #
 
     return ap.parse_args()
 
-class Spider_{name}(ScanSpider):
-    '''
-        Scan Spider class to do: {purpose}
 
-        :param spider_path: spider file path
-        :param jobdir: directory for temporary files
-        :param xnat_project: project ID on XNAT
-        :param xnat_subject: subject label on XNAT
-        :param xnat_session: experiment label on XNAT
-        :param xnat_scan: scan label on XNAT
-        :param xnat_host: host for XNAT if not set in environment variables
-        :param xnat_user: user for XNAT if not set in environment variables
-        :param xnat_pass: password for XNAT if not set in environment variables
-        :param suffix: suffix to the assessor creation
-    '''
-    def __init__(self, spider_path, jobdir, xnat_project, xnat_subject, xnat_session, xnat_scan,
-                 xnat_host=None, xnat_user=None, xnat_pass=None, suffix=""):
-        super(Spider_{name}, self).__init__(spider_path, jobdir, xnat_project, xnat_subject, xnat_session, xnat_scan,
-                                            xnat_host, xnat_user, xnat_pass, suffix)
+class Spider_{name}(ScanSpider):
+    """Scan Spider: Spider_{name}
+
+    :param spider_path: spider file path
+    :param jobdir: directory for temporary files
+    :param xnat_project: project ID on XNAT
+    :param xnat_subject: subject label on XNAT
+    :param xnat_session: experiment label on XNAT
+    :param xnat_scan: scan label on XNAT
+
+    #
+    # ADD MORE PARAMETERS AS NEEDED HERE AND IN __INIT__
+    #
+
+    :param xnat_host: host for XNAT if not set in environment variables
+    :param xnat_user: user for XNAT if not set in environment variables
+    :param xnat_pass: password for XNAT if not set in environment variables
+    :param suffix: suffix to the assessor creation
+    """
+
+    def __init__(self, spider_path, jobdir,
+                 xnat_project, xnat_subject, xnat_session, xnat_scan,
+                 xnat_host=None, xnat_user=None, xnat_pass=None,
+                 suffix=""):
+        """Entry point for Spider_{name} Class."""
+        super(Spider_{name},
+              self).__init__(spider_path, jobdir, xnat_project, xnat_subject,
+                             xnat_session, xnat_scan, xnat_host, xnat_user,
+                             xnat_pass, suffix)
         self.inputs = list()
 
     def pre_run(self, argument_parse):
-        '''
-            Method to download data from XNAT
+        """Method to download data from XNAT.
 
-            :param argument_parse: argument parser object return by parse_args()
-        '''
-        resource = 'XXXX' #resource to download from the scan on XNAT
+        :param argument_parse: argument parser object return by parse_args()
+        """
+        resource = 'XXXX'  # resource to download from the scan on XNAT
         folder = os.path.join(self.jobdir, 'inputs')
         os.makedirs(folder)
         self.inputs.extend(self.download(self.xnat_scan, resource, folder))
@@ -110,25 +123,21 @@ class Spider_{name}(ScanSpider):
         #
 
     def run(self):
-        '''
-            Method running the process for the spider on the inputs data
-        '''
+        """Method running the process for the spider on the inputs data."""
         #
         # CODE THAT YOU WANT TO RUN ON THE DATA
         #
 
     def finish(self):
-        '''
-            Method to copy the results in the Spider Results folder dax.RESULTS_DIR
-        '''
-        self.time_writer('Results saved in folder: %s' % (RESULTS_DIR))
-        results_dict = {{'PDF': pdfpath,
+        """Method to copy the results in dax.RESULTS_DIR."""
+        results_dict = {{'PDF': 'pdfpath'
                         #
                         # ADD OTHER RESULTS YOU WANT TO SAVE
                         #
                         }}
         self.upload_dict(results_dict)
         self.end()
+
 
 if __name__ == '__main__':
     args = parse_args()
@@ -154,66 +163,78 @@ if __name__ == '__main__':
 
     # Finish method to copy results
     spider_obj.finish()
-"""
+'''
 
-SESSION_LEVEL_TEMPLATE = DEFAULT_TEMPLATE+"""
+SESSION_LEVEL_TEMPLATE = DEFAULT_TEMPLATE + '''
 def parse_args():
-    '''
-        Argument parser for the spider input variables
-        by default (set in get_session_argparser):
-            -p       : proj_label
-            -s       : subj_label
-            -e       : sess_label
-            -d       : temp_dir
-            --suffix : suffix (suffix for assessor proctype on XNAT)
-            --host : host for XNAT (default: XNAT_HOST env variable)
-            --user : user on XNAT (default: XNAT_USER env variable)
-        your arguments:
-            ...
+    """Argument parser for the spider input variables.
 
-        :return: argument parser object created by parse_args()
-    '''
-    from argparse import ArgumentParser
+    by default (set in get_session_argparser):
+        -p       : proj_label
+        -s       : subj_label
+        -e       : sess_label
+        -d       : temp_dir
+        --suffix : suffix (suffix for assessor proctype on XNAT)
+        --host : host for XNAT (default: XNAT_HOST env variable)
+        --user : user on XNAT (default: XNAT_USER env variable)
+    your arguments:
+        ...
+
+    :return: argument parser object created by parse_args()
+    """
     ap = spiders.get_session_argparser("{name}", "{purpose}")
 
     #
     # ADD YOUR OTHER OPTIONS FOR THIS SPECIFIC SPIDER
     # example to add one options:
-    # ap.add_argument("--option", dest="option_id", default=None, help="Option description.", required=True)
+    # ap.add_argument("--option", dest="option_id", default=None, \
+help="Option description.", required=True)
     #
 
     return ap.parse_args()
 
-class Spider_{name}(SessionSpider):
-    '''
-        Session Spider class to do: {purpose}
 
-        :param spider_path: spider file path
-        :param jobdir: directory for temporary files
-        :param xnat_project: project ID on XNAT
-        :param xnat_subject: subject label on XNAT
-        :param xnat_session: experiment label on XNAT
-        :param xnat_host: host for XNAT if not set in environment variables
-        :param xnat_user: user for XNAT if not set in environment variables
-        :param xnat_pass: password for XNAT if not set in environment variables
-        :param suffix: suffix to the assessor creation
-    '''
-    def __init__(self, spider_path, jobdir, xnat_project, xnat_subject, xnat_session,
-                 xnat_host=None, xnat_user=None, xnat_pass=None, suffix=""):
-        super(Spider_{name}, self).__init__(spider_path, jobdir, xnat_project, xnat_subject, xnat_session,
-                                            xnat_host, xnat_user, xnat_pass, suffix)
+class Spider_{name}(SessionSpider):
+    """Session Spider: Spider_{name}.
+
+    :param spider_path: spider file path
+    :param jobdir: directory for temporary files
+    :param xnat_project: project ID on XNAT
+    :param xnat_subject: subject label on XNAT
+    :param xnat_session: experiment label on XNAT
+
+    #
+    # ADD MORE PARAMETERS AS NEEDED HERE AND IN __INIT__
+    #
+
+    :param xnat_host: host for XNAT if not set in environment variables
+    :param xnat_user: user for XNAT if not set in environment variables
+    :param xnat_pass: password for XNAT if not set in environment variables
+    :param suffix: suffix to the assessor creation
+    """
+
+    def __init__(self, spider_path, jobdir,
+                 xnat_project, xnat_subject, xnat_session,
+                 xnat_host=None, xnat_user=None, xnat_pass=None,
+                 suffix=""):
+        """Entry point for Spider_{name} Class."""
+        super(Spider_{name},
+              self).__init__(spider_path, jobdir,
+                             xnat_project, xnat_subject, xnat_session,
+                             xnat_host, xnat_user, xnat_pass,
+                             suffix)
         self.inputs = list()
 
     def pre_run(self, argument_parse):
-        '''
-            Method to download data from XNAT
+        """Method to download data from XNAT.
 
-            :param argument_parse: argument parser object return by parse_args()
-        '''
-        resource = 'XXXX' #resource to download from the scan on XNAT
+        :param argument_parse: argument parser object return by parse_args()
+        """
+        resource = 'XXXX'  # resource to download from the scan on XNAT
         folder = os.path.join(self.jobdir, 'inputs')
         os.makedirs(folder)
-        self.inputs.extend(self.download(argument_parse.scan, resource, folder))
+        self.inputs.extend(self.download(argument_parse.scan, resource,
+                                         folder))
 
         #
         # YOU CAN ADD MORE line to download other data LIKE
@@ -221,25 +242,21 @@ class Spider_{name}(SessionSpider):
         #
 
     def run(self):
-        '''
-            Method running the process for the spider on the inputs data
-        '''
+        """Method running the process for the spider on the inputs data."""
         #
         # CODE THAT YOU WANT TO RUN ON THE DATA
         #
 
     def finish(self):
-        '''
-            Method to copy the results in the Spider Results folder dax.RESULTS_DIR
-        '''
-        self.time_writer('Results saved in folder: %s' % (RESULTS_DIR))
-        results_dict = {{'PDF': pdfpath,
+        """Method to copy the results in dax.RESULTS_DIR."""
+        results_dict = {{'PDF': 'pdfpath'
                         #
                         # ADD OTHER RESULTS YOU WANT TO SAVE
                         #
                         }}
         self.upload_dict(results_dict)
         self.end()
+
 
 if __name__ == '__main__':
     args = parse_args()
@@ -264,11 +281,11 @@ if __name__ == '__main__':
 
     # Finish method to copy results
     spider_obj.finish()
-"""
+'''
+
 
 def write_spider(templates):
-    """
-    Create the Spider path with the proper template
+    """Create the Spider path with the proper template.
 
     :param templates: template to use (scan or session)
     :return: None
@@ -283,31 +300,36 @@ def write_spider(templates):
     f_obj.writelines(spider_code)
     f_obj.close()
 
+
 def parse_args():
-    """
-    Method to parse arguments base on ArgumentParser
+    """Method to parse arguments base on ArgumentParser.
 
     :return: parser object parsed
     """
     from argparse import ArgumentParser
     usage = "Generate your Spider.py following the dax template for spider."
     argp = ArgumentParser(prog='GenerateSpiderTemplate', description=usage)
-    argp.add_argument('-n', dest='name', help='Name for Spider. E.G: fMRIQA.', required=True)
-    argp.add_argument('-v', dest='version',
-                      help='Spider version (format: X.Y.Z). E.G: 1.0.0', required=True)
+    argp.add_argument('-n', dest='name', required=True,
+                      help='Name for Spider. E.G: fMRIQA.')
+    argp.add_argument('-v', dest='version', required=True,
+                      help='Spider version (format: X.Y.Z). E.G: 1.0.0')
     argp.add_argument('-a', dest='author', help='Author name.', required=True)
-    argp.add_argument('-e', dest='email', help='Author email address.', required=True)
-    argp.add_argument('-p', dest='purpose', help='Spider purpose.', required=True)
-    argp.add_argument('-c', dest='on_scan', action='store_true', help='Use Scan type Spider.')
-    argp.add_argument('-d', dest='directory',
-                      help="Directory where the spider file will be generated. Default: current directory.",
-                      default=None)
+    argp.add_argument('-e', dest='email', required=True,
+                      help='Author email address.')
+    argp.add_argument('-p', dest='purpose', required=True,
+                      help='Spider purpose.')
+    argp.add_argument('-c', dest='on_scan', action='store_true',
+                      help='Use Scan type Spider.')
+    argp.add_argument('-d', dest='directory', default=None,
+                      help="Directory where the spider file will be generated. \
+Default: current directory.")
     return argp.parse_args()
+
 
 if __name__ == '__main__':
     ARGS = parse_args()
 
-    ## Get a proper name from the input
+    # Get a proper name from the input
     # remove .py if present at the end of the file
     if ARGS.name.endswith('.py'):
         ARGS.name = ARGS.name[:-3]
@@ -320,10 +342,10 @@ if __name__ == '__main__':
     if ARGS.name[-1] == '_':
         ARGS.name = ARGS.name[:-1]
 
-    ## Check version
+    # Check version
     if not spiders.is_good_version(ARGS.version):
         err = "wrong format version given to script." + \
-              "It must follow the X.Y.Z template with X, Y, and Z integers." + \
+              "It must follow the X.Y.Z template with X, Y, and Z integers." +\
               "Look at http://semver.org for more information."
         raise ValueError(err)
 
@@ -335,8 +357,10 @@ if __name__ == '__main__':
     else:
         SPIDER_FPATH = os.path.join(os.getcwd(), SPIDER_NAME)
     if ARGS.on_scan:
-        print "Generating file %s for scan spider %s ..." % (SPIDER_FPATH, ARGS.name)
+        print "Generating file %s for scan spider %s ..." % \
+              (SPIDER_FPATH, ARGS.name)
         write_spider(SCAN_LEVEL_TEMPLATE)
     else:
-        print "Generating file %s for session spider %s ..." % (SPIDER_FPATH, ARGS.name)
+        print "Generating file %s for session spider %s ..." % \
+              (SPIDER_FPATH, ARGS.name)
         write_spider(SESSION_LEVEL_TEMPLATE)

--- a/bin/dax_tools/dax_build
+++ b/bin/dax_tools/dax_build
@@ -21,9 +21,10 @@ def parse_args():
     ap.add_argument('--project', dest='project', help='Project ID from XNAT to run dax_build on locally (only one project).', default=None)
     ap.add_argument('--sessions', dest='sessions', help='list of sessions (labels) from XNAT to run dax_build on locally.', default=None)
     ap.add_argument('--nodebug', dest='debug', action='store_false', help='Avoid printing DEBUG information.')
+    ap.add_argument('--mod', dest='mod_delta', help='Run build if modified within this window', default=None)
     return ap.parse_args()
 
 if __name__ == '__main__':
     args = parse_args()
     
-    dax.bin.build(args.settings_path, args.logfile, args.debug, args.project, args.sessions)
+    dax.bin.build(args.settings_path, args.logfile, args.debug, args.project, args.sessions, args.mod_delta)

--- a/bin/dax_tools/dax_setup
+++ b/bin/dax_tools/dax_setup
@@ -1,22 +1,44 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""dax_setup to setup variables for executables."""
 
 import os
 import sys
+import glob
 import socket
-import shutil
 import getpass
-import readline, glob
+import readline
+
 
 def complete(text, state):
+    """Function to help tab completion path when using dax_setup."""
     return (glob.glob(text+'*')+[None])[state]
+
 
 readline.set_completer_delims(' \t\n;')
 readline.parse_and_bind("tab: complete")
 readline.set_completer(complete)
 
-DAX_SETTINGS_TEMPLATE="""; High level admin information. E.g. email address
+BASH_PROFILE_XNAT = """
+# Call for .xnat_profile files containing xnat logins:
+if [ -f ~/.xnat_profile ]; then
+    . ~/.xnat_profile
+fi
+"""
+
+XNAT_PROFILE_TEMPLATE = """###### XNAT PROFILE FILE ######
+# File running every time you open a new terminal (called by .bash_profile)
+# created by dax_setup to setup your credentials as environment variables.
+# Xnat host:
+export XNAT_HOST="{host}"
+# Xnat username
+export XNAT_USER="{user}"
+# Xnat password
+export XNAT_PASS="{pwd}"
+"""
+
+DAX_SETTINGS_TEMPLATE = """; High level admin information. E.g. email address
 [admin]
 user_home={user_home}
 admin_email={admin_email}
@@ -25,7 +47,10 @@ smtp_from={smtp_from}
 smtp_pass={smtp_pass}
 xsitype_include={xsitype_include}
 
-; Deep information about the cluster. This should include commands that are grid-specific to get job id, walltime usage etc. Additionally, there are several templates that needed to be specified. See readthedocs for a description
+; Deep information about the cluster. This should include commands that \
+are grid-specific to get job id, walltime usage etc. Additionally, there \
+are several templates that needed to be specified. See readthedocs for a \
+description.
 [cluster]
 cmd_submit={cmd_submit}
 prefix_jobid={prefix_jobid}
@@ -48,12 +73,13 @@ results_dir={results_dir}
 max_age={max_age}
 launcher_type={launcher_type}
 
-; Information used to connect to REDCap databases if DAX_manager is used
+; Information used to connect to REDCap databases if DAX_manager is used.
 [redcap]
 api_url={api_url}
 api_key_dax={api_key_dax}
 
-; Keeping this outside of redcap so we dont have to add a prefix to all the variables
+; Keeping this outside of redcap so we dont have to add a prefix to \
+all the variables.
 [dax_manager]
 project={dm_project}
 settingsfile={dm_settingsfile}
@@ -79,6 +105,21 @@ max_age={dm_max_age}
 admin_email={dm_admin_email}
 """
 
+DEFAULT_TOOLS_SETUP = {
+    'user_home': os.path.expanduser('~'),
+    'admin_email': '',
+    'smtp_host': '',
+    'smtp_from': '',
+    'smtp_pass': '',
+    'xsitype_include': 'proc:genProcData',
+    'gateway': '',
+    'root_job_dir': '/tmp',
+    'queue_limit': '600',
+    'results_dir': '~/RESULTS_XNAT_SPIDER',
+    'max_age': '14',
+    'api_url': '',
+    'api_key_dax': ''}
+
 DEFAULT_FILE_FIELDS = ['cmd_get_job_memory', 'cmd_get_job_node',
                        'cmd_count_nb_jobs', 'cmd_get_job_status',
                        'cmd_get_job_walltime', 'job_template']
@@ -96,7 +137,8 @@ SGE_TEMPLATE = """#!/bin/bash
 #$ -cwd
 #$ -V
 uname -a # outputs node info (name, date&time, type, OS, etc)
-export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=${job_ppn} #set the variable to use only good amount of ppn
+export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=${job_ppn} #set the variable \
+to use only the right amount of ppn
 SCREEN=$$$$$$$$
 SCREEN=${SCREEN:0:8}
 echo 'Screen display number for xvfb-run' $SCREEN
@@ -115,7 +157,8 @@ DEFAULT_SGE_DICT = {'cmd_submit': 'qsub',
                     'complete_status': '',
                     'cmd_get_job_memory': "echo ''\n",
                     'cmd_get_job_node': "echo ''\n",
-                    'cmd_get_job_status': "qstat -u $USER | grep ${jobid} | awk {'print $5'}\n",
+                    'cmd_get_job_status': "qstat -u $USER | grep ${jobid} \
+| awk {'print $5'}\n",
                     'cmd_get_job_walltime': "echo ''\n",
                     'job_extension_file': '.pbs',
                     'job_template': SGE_TEMPLATE,
@@ -131,7 +174,8 @@ SLURM_TEMPLATE = """#!/bin/bash
 #SBATCH -o ${job_output_file}
 
 uname -a # outputs node info (name, date&time, type, OS, etc)
-export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=${job_ppn} #set the variable to use only good amount of ppn
+export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=${job_ppn} #set the variable \
+to use only the right amount of ppn
 SCREEN=$$$$$$$$
 SCREEN=${SCREEN:0:8}
 echo 'Screen display number for xvfb-run' $SCREEN
@@ -144,14 +188,20 @@ ${job_cmds}\n"""
 DEFAULT_SLURM_DICT = {'cmd_submit': 'sbatch',
                       'prefix_jobid': 'Submitted batch job ',
                       'suffix_jobid': '\n',
-                      'cmd_count_nb_jobs': 'squeue -u masispider,vuiiscci --noheader | wc -l\n',
+                      'cmd_count_nb_jobs': 'squeue -u masispider,vuiiscci \
+--noheader | wc -l\n',
                       'queue_status': 'Q',
                       'running_status': 'R',
-                      'complete_status': 'slurm_load_jobs error: Invalid job id specified\n',
-                      'cmd_get_job_memory': "sacct -j ${jobid}.batch --format MaxRss --noheader | awk '{print $1+0}'\n",
-                      'cmd_get_job_node': 'sacct -j ${jobid}.batch --format NodeList --noheader\n',
-                      'cmd_get_job_status': 'slurm_load_jobs error: Invalid job id specified\n',
-                      'cmd_get_job_walltime': 'sacct -j ${jobid}.batch --format CPUTime --noheader\n',
+                      'complete_status': 'slurm_load_jobs error: Invalid job \
+id specified\n',
+                      'cmd_get_job_memory': "sacct -j ${jobid}.batch --format \
+MaxRss --noheader | awk '{print $1+0}'\n",
+                      'cmd_get_job_node': 'sacct -j ${jobid}.batch --format \
+NodeList --noheader\n',
+                      'cmd_get_job_status': 'slurm_load_jobs error: Invalid \
+job id specified\n',
+                      'cmd_get_job_walltime': 'sacct -j ${jobid}.batch \
+--format CPUTime --noheader\n',
                       'job_extension_file': '.slurm',
                       'job_template': SLURM_TEMPLATE,
                       'email_opts': 'FAIL'}
@@ -166,7 +216,8 @@ MOAB_TEMPLATE = """#!/bin/bash
 #PBS -j y
 
 uname -a # outputs node info (name, date&time, type, OS, etc)
-export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=${job_ppn} #set the variable to use only good amount of ppn
+export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=${job_ppn} #set the variable \
+to use only the right amount of ppn
 SCREEN=$$$$$$$$
 SCREEN=${SCREEN:0:8}
 echo 'Screen display number for xvfb-run' $SCREEN
@@ -176,25 +227,40 @@ xvfb-run --wait=5 \
 --server-args="-screen 0 1920x1200x24 -ac +extension GLX" \
 ${job_cmds}\n"""
 
-DEFAULT_MOAB_DICT = {'cmd_submit': 'qsub',
-                     'prefix_jobid': '',
-                     'suffix_jobid': '.',
-                     'cmd_count_nb_jobs': 'qstat | grep $USER | wc -l\n',
-                     'queue_status': 'Q',
-                     'running_status': 'R',
-                     'complete_status': 'C',
-                     'cmd_get_job_memory': "rsh vmpsched 'tracejob -n ${numberofdays} ${jobid}' 2> /dev/null | awk -v FS='(resources_used.mem=|kb)' '{print $2}' | sort -u | tail -1\n",
-                     'cmd_get_job_node': "echo ''\n",
-                     'cmd_get_job_status': "qstat -f ${jobid} | grep job_state | awk {'print $3'}\n",
-                     'cmd_get_job_walltime': "rsh vmpsched 'tracejob -n ${numberofdays} ${jobid}' 2> /dev/null | awk -v FS='(resources_used.walltime=|\n)' '{print $2}' | sort -u | tail -1\n",
-                     'job_extension_file': '.pbs',
-                     'job_template': MOAB_TEMPLATE,
-                     'email_opts': 'a'}
+DEFAULT_MOAB_DICT = {
+  'cmd_submit': 'qsub',
+  'prefix_jobid': '',
+  'suffix_jobid': '.',
+  'cmd_count_nb_jobs': 'qstat | grep $USER | wc -l\n',
+  'queue_status': 'Q',
+  'running_status': 'R',
+  'complete_status': 'C',
+  'cmd_get_job_memory': "rsh vmpsched 'tracejob -n ${numberofdays} ${jobid}' \
+2> /dev/null | awk -v FS='(resources_used.mem=|kb)' '{print $2}' \
+| sort -u | tail -1\n",
+  'cmd_get_job_node': "echo ''\n",
+  'cmd_get_job_status': "qstat -f ${jobid} | grep job_state \
+| awk {'print $3'}\n",
+  'cmd_get_job_walltime': "rsh vmpsched 'tracejob -n ${numberofdays} ${jobid}' \
+2> /dev/null | awk -v FS='(resources_used.walltime=|\n)' '{print $2}' \
+| sort -u | tail -1\n",
+  'job_extension_file': '.pbs',
+  'job_template': MOAB_TEMPLATE,
+  'email_opts': 'a'}
+
 
 class DAX_Setup_Handler(object):
+    """DAX_Setup_Handler Class.
+
+    Class to write the dax_settings.ini files required to run any
+    dax executables.
+    """
 
     def __init__(self):
-        dax_settings_file = os.path.join(os.path.expanduser('~'), '.dax_settings.ini')
+        """Entry Point for DAX_Setup_Handler class."""
+        self._set_xnat_credentials()
+        dax_settings_file = os.path.join(os.path.expanduser('~'),
+                                         '.dax_settings.ini')
         if os.path.isfile(dax_settings_file):
             sys.stdout.write('~/.dax_settings.ini exists. Exiting\n')
             sys.exit(1)
@@ -207,19 +273,22 @@ class DAX_Setup_Handler(object):
         # If using DAX Manager, users can use defaults
         self.use_redcap_defaults = False
 
+        # type of setup for dax: tools for xnat_tools/Freesurfer_tools
+        #                        cluster for full dax package tools
+        self.dax_setup_type = 'cluster'
+
     def _prompt(self, message, default=None, is_path=False):
-        """
-        Method to prompt a user for an input for each key in the template.
+        """Method to prompt a user for an input for each key in the template.
 
         :param message: A string that prompts the user for input
         :param default: Default value for value (if desired)
         :param is_path: if the value needs to be a path
         :return: String of the input
-
         """
         stdin = ''
         if default:
-            stdin = raw_input("%s Default <%s> [press enter to use default]: " % (message, default))
+            stdin = raw_input("%s Default <%s> \
+[press Enter to use default]: " % (message, default))
             if len(stdin.lower()) == 0:
                 stdin = default
         else:
@@ -236,314 +305,298 @@ class DAX_Setup_Handler(object):
         return stdin
 
     def _set(self, key, value):
-        """
-        Update the dictionary with the key/value pair for the template
+        """Update the dictionary with the key/value pair for the template.
+
         :param key: String key name in the template
         :param value: String value associated with the key
         :return: None
         """
-
         self.settings_dict.__setitem__(key, value)
 
     def _set_null(self, key):
-        """
-        Update the dictionary with the value of '' for the key
+        """Update the dictionary with the value of '' for the key.
+
         :param key: String key name in the template
         :return: None
         """
-
         self.settings_dict.__setitem__(key, '')
 
     def _get_user_home(self):
-        """
-        Get the default user home directory. If the user wants a different one,
-         prompt for it
+        """Get the default user home directory.
+
+        If the user wants a different one, prompt for it.
 
         :return: None
-
         """
         default = os.path.expanduser('~')
-        value = self._prompt("Please enter your home directory.", default, is_path=True)
+        value = self._prompt("Please enter your home directory.",
+                             default, is_path=True)
         self._set('user_home', value)
 
     def _get_admin_email(self):
-        """
-        Prompt the user for the admin email address
+        """Prompt the user for the admin email address.
 
         :return: None
-
         """
-        value = self._prompt("Please enter email address for admin. "
-                             "All emails will get sent here : ")
+        value = self._prompt("Please enter email address for admin. \
+All emails will get sent here : ")
         self._set('admin_email', value)
 
     def _get_smtp_from(self):
-        """
-        Prompt the user email address where emails should come from
+        """Prompt the user email address where emails should come from.
 
         :return: String of the smtp_from value, None if emtpy
-
         """
-        value = self._prompt("Please enter an email address where emails"
-                             " should be sent from : ")
+        value = self._prompt("Please enter an email address where emails \
+should be sent from : ")
         self._set('smtp_from', value)
 
     def _get_smtp_host(self):
-        """
-        Prompt the user for the smtp_host if smtp_from is not null
+        """Prompt the user for the smtp_host if smtp_from is not null.
 
         :return: None
-
         """
         if self.settings_dict['smtp_from'] != '':
-            value = self._prompt("Please enter the SMTP host associated with email"
-                                 " address %s : " % self.settings_dict['smtp_from'])
+            value = self._prompt("Please enter the SMTP host associated with \
+email address %s : " % self.settings_dict['smtp_from'])
             self._set('smtp_host', value)
         else:
             self._set_null('smtp_host')
 
     def _get_smtp_pass(self):
-        """
-        Prompt the user for the password associated with the email if
-         smtp_from is set
+        """Prompt the user for the password.
 
+        The password us associated with the email if smtp_from is set.
         :return: None
-
         """
         if self.settings_dict['smtp_from'] != '':
-            value = getpass.getpass("Please enter the password associated with email"
-                                    " address %s : " % self.settings_dict['smtp_from'])
+            value = getpass.getpass("Please enter the password associated with \
+email address %s : " % self.settings_dict['smtp_from'])
             self._set('smtp_pass', value)
         else:
             self._set_null('smtp_pass')
 
     def _get_xsitype_include(self):
-        """
-        Prompt the user for the xsitypes for DAX to access in the project
+        """Prompt the user for the xsitypes for DAX to access in the project.
 
         :return: None
-
         """
-        value = self._prompt("Please enter the xsitypes you would like DAX"
-                             " to access in your XNAT instance : ")
+        value = self._prompt("Please enter the xsitypes you would like DAX \
+to access in your XNAT instance : ")
         self._set('xsitype_include', value)
 
     # Begin cluster section
     def _get_cmd_submit(self):
-        """
-        Prompt the user for the command to submit a job to the grid
+        """Prompt the user for the command to submit a job to the grid.
 
         :return: None
-
         """
-        value = self._prompt("What command is used to submit your batch file? [e.g., qsub, sbatch] : ")
+        value = self._prompt("What command is used to submit your batch file? \
+[e.g., qsub, sbatch] : ")
         self._set('cmd_submit', value)
 
     def _get_prefix_jobid(self):
-        """
-        Prompt the user for a string to let them know the job was submitted before printing the job ID
+        """Prompt the user for a string.
+
+        The string represents the prefix in the string prompt by the cluster
+         before the Job ID after submitting a job.
 
         :return: None
-
         """
-        value = self._prompt("Please enter a string to print before the job id after submission.", 'Submitted batch job')
+        value = self._prompt("Please enter a string to print before the \
+job id after submission.", 'Submitted batch job')
         self._set('prefix_jobid', value)
 
     def _get_suffix_jobid(self):
-        """
-        Prompt the user for the suffix of the job submission string
+        """Prompt the user for the suffix of the job submission string.
 
         :return: None
-
         """
-        value = self._prompt("Please enter a string to print after the job id after submission.", '\\n')
+        value = self._prompt("Please enter a string to print after the \
+job id after submission.", '\\n')
         self._set('suffix_jobid', value)
 
     def _get_cmd_count_nb_jobs(self):
-        """
-        Prompt the user for the path to where the template file is for the
-         command to count the number of jobs
+        """Prompt the user for the path.
+
+        The path given correspond to where the template file is for the
+         command to count the number of jobs.
 
         :return: None
-
         """
-        value = self._prompt("Please enter the full path to text file"
-                             " containing the command used to count the number"
-                             " of jobs in the queue : ", is_path=True)
+        value = self._prompt("Please enter the full path to text file \
+containing the command used to count the number of jobs in the queue : ",
+                             is_path=True)
         self._set('cmd_count_nb_jobs', value)
 
     def _get_cmd_get_job_status(self):
-        """
-        Prompt the user for the path to where the tempalte file is for the
-         command to get the status of a job by job id
+        """Prompt the user for the path.
+
+        The path given correspond to where the tempalte file is for the
+         command to get the status of a job by job id.
 
         :return: None
-
         """
-        value = self._prompt("Please enter the full path to text file"
-                             " containing the command used to check the running"
-                             " status of a job : ", is_path=True)
+        value = self._prompt("Please enter the full path to text file \
+containing the command used to check the running status of a job : ",
+                             is_path=True)
         self._set('cmd_get_job_status', value)
 
     def _get_queue_status(self):
-        """
-        Prompt the user for the path to where the template file is for the
-         command to see if a job failed
+        """Prompt the user for the string.
 
-        :return: None
-
+        The string indicates the queueing status of a job on the cluster.
+         (Complete/C etc).
         """
-        value = self._prompt("Please enter the string the job scheduler would "
-                             "use to indicate that a job is 'in the queue' : ")
+        value = self._prompt("Please enter the string the job scheduler would \
+use to indicate that a job is 'in the queue' : ")
         self._set('queue_status', value)
 
     def _get_running_status(self):
-        """
-        Prompt the user for the string indicating the running status of a job
-         (Running/R etc)
+        """Prompt the user for the string.
+
+        The string indicates the running status of a job on the cluster.
+         (Running/R etc).
 
         :return: None
-
         """
-        value = self._prompt("Please enter the string the job scheduler would "
-                             "use to indicate that a job is 'running' : ")
+        value = self._prompt("Please enter the string the job scheduler would \
+use to indicate that a job is 'running' : ")
         self._set('running_status', value)
 
     def _get_complete_status(self):
-        """
-        Prompt the user for the string indicating the running status of a job
-         (Complete/C etc)
+        """Prompt the user for the string.
+
+        The string indicates the complete status of a job on the cluster.
+         (Complete/C etc).
 
         :return: None
-
         """
-        value = self._prompt("Please enter the string the job scheduler would "
-                             "use to indicate that a job is 'complete' : ")
+        value = self._prompt("Please enter the string the job scheduler would \
+use to indicate that a job is 'complete' : ")
         self._set('complete_status', value)
 
     def _get_cmd_get_job_memory(self):
-        """
-        Prompt the user for the full path to the file containing the command
-         used to see how much memory a job used
+        """Prompt the user for the full path.
+
+        The path given correspond to the file containing the command
+         used to see how much memory a job used.
 
         :return: None
-
         """
-        value = self._prompt("Please enter the full path to the text file"
-                             " containing the command used to see how much"
-                             " memory a job used : ", is_path=True)
+        value = self._prompt("Please enter the full path to the text file \
+containing the command used to see how much memory a job used : ",
+                             is_path=True)
         self._set('cmd_get_job_memory', value)
 
     def _get_cmd_get_job_walltime(self):
-        """
-        Prompt the user for the full path to the file containing the command
-         used to see how much walltime a job used
+        """Prompt the user for the full path.
+
+        The path given correspond to the file containing the command
+         used to see how much walltime a job used.
 
         :return: None
 
         """
-        value = self._prompt("Please enter the full path to the text file"
-                             " containing the command used to see how much"
-                             " walltime a job used : ", is_path=True)
+        value = self._prompt("Please enter the full path to the text file \
+containing the command used to see how much walltime a job used : ",
+                             is_path=True)
         self._set('cmd_get_job_walltime', value)
 
     def _get_cmd_get_job_node(self):
-        """
-        Prompt the user for the full path to the file containing the command
-         used to see what node a job used
+        """Prompt the user for the full path.
+
+        The path given correspond to the file containing the command
+         used to see what node a job used.
 
         :return: None
-
         """
-        value = self._prompt("Please enter the full path to the text file"
-                             " containing the command used to see which node"
-                             " a job used : ", is_path=True)
+        value = self._prompt("Please enter the full path to the text file \
+containing the command used to see which node a job used : ", is_path=True)
         self._set('cmd_get_job_node', value)
 
     def _get_job_extension_file(self):
-        """
-        Prompt the user for a job file extension (.pbs, .slurm etc)
+        """Prompt the user for a job file extension (.pbs, .slurm etc).
 
         :return: None
-
         """
-        value = self._prompt("Please enter an extension for the job batch file.", '.pbs')
+        value = self._prompt("Please enter an extension for the job \
+batch file.", '.pbs')
         self._set('job_extension_file', value)
 
     def _get_job_template(self):
-        """
-        Prompt the user for the full path to the file containing the template
-         used to generate the batch file
+        """Prompt the user for the full path.
+
+        The path given correspond to the file containing the template
+         used to generate the batch file.
 
         :return: None
-
         """
-        value = self._prompt("Please enter the full path to the text file"
-                             " containing the template used to generate the"
-                             " batch script : ", is_path=True)
+        value = self._prompt("Please enter the full path to the text file \
+containing the template used to generate the batch script : ", is_path=True)
         self._set('job_template', value)
 
     def _get_email_opts(self):
-        """
-        Prompt the user for when they want to be notified about a job
+        """Prompt the user for when they want to be notified about a job.
 
         :return: None
-
         """
-        value = self._prompt("Please provide the options for the email notification"
-                             " for a job as defined by your grid scheduler : ")
+        value = self._prompt("Please provide the options for the email \
+notification for a job as defined by your grid scheduler : ")
         self._set('email_opts', value)
 
     def _get_gateway(self):
-        """
-        Prompt the user for the hostname of the server to run on
+        """Prompt the user for the hostname of the server to run on.
 
         :return: None
-
         """
         default = socket.gethostname()
-        value = self._prompt("Please enter the hostname of the server to run dax on.", default)
+        value = self._prompt("Please enter the hostname of the server \
+to run dax on.", default)
         self._set('gateway', value)
 
     def _get_root_job_dir(self):
-        """
-        Prompt the user for the directory where the data should be stored on the node
+        """Prompt the user for the directory.
+
+        The directory represents the folder where the data should be stored
+         on the node.
 
         :return: None
-
         """
-        value = self._prompt("Please enter where the data should be stored on the node.", '/tmp', is_path=True)
+        value = self._prompt("Please enter where the data should be stored \
+on the node.", '/tmp', is_path=True)
         self._set('root_job_dir', value)
 
     def _get_queue_limit(self):
-        """
-        Prompt the user for the maximum number of jobs that should run at a time
+        """Prompt the user for the maximum number of jobs that should run at a time.
 
         :return: None
-
         """
-        value = self._prompt("Please enter the maximum number of jobs that should run at once.", '600')
+        value = self._prompt("Please enter the maximum number of jobs \
+that should run at once.", '600')
         self._set('queue_limit', value)
 
     def _get_results_dir(self):
-        """
-        Prompt the user where the data should get uploaded to when done
+        """Prompt the user where the data should get uploaded to when done.
 
         :return: None
-
         """
-        default = os.path.join(os.path.expanduser('~'), 'RESULTS_XNAT_SPIDER')
-        value = self._prompt("Please enter directory where data will get copied to for upload.", default, is_path=True)
+        default = os.path.join(self.settings_dict['user_home'],
+                               'RESULTS_XNAT_SPIDER')
+        value = self._prompt("Please enter directory where data will get \
+copied to for upload.", default, is_path=True)
         self._set('results_dir', value)
 
     def _get_max_age(self):
-        """
-        Prompt the user for the number of days dax should ignore the session before re-running dax_build
+        """Prompt the user for the number of days.
+
+        Dax will ignore the session that are already built. It will rerun any
+         sessions that pass the maximun age chosen. Default: 7days.
 
         :return: None
-
         """
-        value = self._prompt("Please max days before re-running dax_build on a session.", '7')
+        value = self._prompt("Please max days before re-running dax_build \
+on a session.", '7')
         self._set('max_age', value)
         
     def _get_launcher_type(self):
@@ -571,8 +624,7 @@ class DAX_Setup_Handler(object):
 
     # redcap section
     def _get_api_url(self):
-        """
-        Prompt user for the REDCap API URL
+        """Prompt user for the REDCap API URL.
 
         :return: None
 
@@ -581,46 +633,49 @@ class DAX_Setup_Handler(object):
         self._set('api_url', value)
 
     def _get_api_key_dax(self):
-        """
-        Prompt the user to enter an API key to connect to REDCap for DAX Manager
+        """Prompt the user to enter an API key to connect to REDCap for DAX Manager.
 
         :return: None
 
         """
-        value = self._prompt("Please enter the key to connect to the DAX Manager REDCap database : ")
+        value = self._prompt("Please enter the key to connect to the \
+DAX Manager REDCap database : ")
         self._set('api_key_dax', value)
 
     def _get_dax_manager_dict(self):
-        """
-        Set the variables for DAX_manager to be defaults to try to keep debugging easier.
+        """Set the variables for DAX_manager to be defaults.
+
         :return: None
         """
         if self.settings_dict['api_key_dax'] != '':
-            print '\n  DAX_MANAGER set using Vanderbilt default REDCap fields. Edit .dax_settings.ini to change the fields name.'
-            self._set('dm_project','dax_project')
-            self._set('dm_settingsfile','dax_settings_full_path')
-            self._set('dm_masimatlab','dax_masimatlab')
-            self._set('dm_tmp','dax_tmp_directory')
-            self._set('dm_logsdir','dax_logs_path')
-            self._set('dm_user','dax_cluster_user')
-            self._set('dm_gateway','dax_gateway')
-            self._set('dm_email','dax_cluster_email')
-            self._set('dm_queue','dax_queue_limit')
-            self._set('dm_priority','dax_proj_order')
-            self._set('dm_email_opts','dax_job_email_options')
-            self._set('dm_dax_build_start_date','dax_build_start_date')
-            self._set('dm_dax_build_end_date','dax_build_end_date')
-            self._set('dm_dax_build_pid','dax_build_pid')
-            self._set('dm_dax_update_tasks_start_date','dax_update_tasks_start_date')
-            self._set('dm_dax_update_tasks_end_date','dax_update_tasks_end_date')
-            self._set('dm_dax_update_tasks_pid','dax_update_tasks_pid')
-            self._set('dm_dax_launch_start_date','dax_launch_start_date')
-            self._set('dm_dax_launch_end_date','dax_launch_end_date')
-            self._set('dm_dax_launch_pid','dax_launch_pid')
-            self._set('dm_max_age','dax_max_age')
-            self._set('dm_admin_email','dax_email_address')
+            print '\n  DAX_MANAGER set using Vanderbilt default REDCap fields. \
+Edit .dax_settings.ini to change the fields name.'
+            self._set('dm_project', 'dax_project')
+            self._set('dm_settingsfile', 'dax_settings_full_path')
+            self._set('dm_masimatlab', 'dax_masimatlab')
+            self._set('dm_tmp', 'dax_tmp_directory')
+            self._set('dm_logsdir', 'dax_logs_path')
+            self._set('dm_user', 'dax_cluster_user')
+            self._set('dm_gateway', 'dax_gateway')
+            self._set('dm_email', 'dax_cluster_email')
+            self._set('dm_queue', 'dax_queue_limit')
+            self._set('dm_priority', 'dax_proj_order')
+            self._set('dm_email_opts', 'dax_job_email_options')
+            self._set('dm_dax_build_start_date', 'dax_build_start_date')
+            self._set('dm_dax_build_end_date', 'dax_build_end_date')
+            self._set('dm_dax_build_pid', 'dax_build_pid')
+            self._set('dm_dax_update_tasks_start_date',
+                      'dax_update_tasks_start_date')
+            self._set('dm_dax_update_tasks_end_date',
+                      'dax_update_tasks_end_date')
+            self._set('dm_dax_update_tasks_pid', 'dax_update_tasks_pid')
+            self._set('dm_dax_launch_start_date', 'dax_launch_start_date')
+            self._set('dm_dax_launch_end_date', 'dax_launch_end_date')
+            self._set('dm_dax_launch_pid', 'dax_launch_pid')
+            self._set('dm_max_age', 'dax_max_age')
+            self._set('dm_admin_email', 'dax_email_address')
         else:
-            print '\n  REDCap not used. Setting the dax_manager to null.'
+            print 'Warning: REDCap not used. Setting the dax_manager to null.'
             self._set_null('dm_project')
             self._set_null('dm_settingsfile')
             self._set_null('dm_masimatlab')
@@ -645,28 +700,41 @@ class DAX_Setup_Handler(object):
             self._set_null('dm_admin_email')
 
     def _use_cluster_default(self):
-        """
-        Ask the user if they want to use default settings
+        """Ask the user if they want to use default settings for cluster section.
 
         :return: True if using default, False otherwise
         """
         value = ''
         while value.lower() not in ['yes', 'no', 'n', 'y']:
-            value = self._prompt("Do you want to download default templates file from DAX? [yes/no] ")
+            value = self._prompt("Do you want to download default templates \
+file from DAX? [yes/no] ")
         if value in ['yes', 'y']:
             return True
         else:
             return False
 
-    def _set_cluster_default(self):
-        """
-        Use the default cluster settings from the cluster type selected
+    def _set_cluster_default(self, ctype=False):
+        """Use the default cluster settings from the cluster type selected.
 
+        :param ctype: True if set to default
         :return: None
         """
-        cluster_type = '0'
-        while cluster_type not in ['1', '2', '3']:
-            cluster_type = self._prompt("Which cluster are you using? [1.SGE 2.SLURM 3.MOAB] ")
+        if ctype:
+            cluster_type = '1'
+        else:
+            cluster_type = '0'
+            while cluster_type not in ['1', '2', '3']:
+                cluster_type = self._prompt("Which cluster are you using? \
+        [1.SGE 2.SLURM 3.MOAB] ")
+            print 'Warning: You can edit the cluster templates files at any \
+        time in ~/.dax_templates/'
+            self._get_gateway()
+            self._get_root_job_dir()
+            self._get_queue_limit()
+            self._get_results_dir()
+            self._get_max_age()
+            self._get_launcher_type()
+
         if cluster_type == '1':
             cluster_dict = DEFAULT_SGE_DICT
         elif cluster_type == '2':
@@ -674,81 +742,151 @@ class DAX_Setup_Handler(object):
         else:
             cluster_dict = DEFAULT_MOAB_DICT
 
-        #Copy the files from the template:
-        templates_path = os.path.join(os.path.expanduser('~'), '.dax_templates')
-        if not os.path.exists(templates_path): os.makedirs(templates_path)
+        # Copy the files from the template:
+        templates_path = os.path.join(self.settings_dict['user_home'],
+                                      '.dax_templates')
+        if not os.path.exists(templates_path):
+            os.makedirs(templates_path)
         for field, value in cluster_dict.items():
             if field in DEFAULT_FILE_FIELDS:
-                with open(os.path.join(templates_path, field+'.txt'), 'w') as fid:
+                with open(os.path.join(templates_path,
+                          field+'.txt'), 'w') as fid:
                     fid.writelines(value)
                 self._set(field, os.path.join(templates_path, field+'.txt'))
             else:
                 self._set(field, value)
-        self._get_gateway()
-        self._get_root_job_dir()
-        self._get_queue_limit()
-        self._get_results_dir()
-        self._get_max_age()
-        self._get_launcher_type()
+
+    def _set_xnat_credentials(self):
+        """Ask User for xnat credentials and store it on the node.
+
+        :return: None
+        """
+        xnat_profile = os.path.join(os.path.expanduser('~'), '.xnat_profile')
+        if not os.path.isfile(xnat_profile):
+            print 'Setting XNAT credentials:'
+            host = self._prompt("Please enter your XNAT host: ")
+            user = self._prompt("Please enter your XNAT username: ")
+            pwd = getpass.getpass(prompt='Please enter your XNAT password: ')
+            with open(xnat_profile, 'w') as fid:
+                fid.writelines(XNAT_PROFILE_TEMPLATE.format(host=host,
+                                                            user=user,
+                                                            pwd=pwd))
+            print 'Please run the ~/.xnat_profile to set up the credentials.'
+            # add .xnat_profile to your profile file:
+            init_profile()
+
+    def _set_dax_setup_type(self):
+        """Ask the user if they want to use tools dax_setup_type for dax.
+
+        :return:  None
+        """
+        value = ''
+        while value.lower() not in ['yes', 'no', 'n', 'y']:
+            value = self._prompt("Do you want to select default settings \
+adapted for Xnat_tools/Freesurfer_tools use only? [yes/no]")
+        if value in ['yes', 'y']:
+            self.dax_setup_type = 'tools'
+
+    def _set_tools_setup(self):
+        """Set the values from the default tools setup to the dax_settings.ini.
+
+        :return: None
+        """
+        print """Warning: Not recommended if you want to use dax_tools.\n\
+         Read the wiki for more information on dax_setup and setting dax for \
+cluster use.\n         Wiki: https://github.com/VUIIS/dax/wiki/DAX-Set-up"""
+        for field, value in DEFAULT_TOOLS_SETUP.items():
+            self._set(field, value)
+        self._set_cluster_default(ctype='SGE')
+        self._get_dax_manager_dict()
 
     def write(self):
-        """
-        Write the all of the config options to the ~/.dax_settings.ini file
-                :return: None
+        """Write the all of the config options to the ~/.dax_settings.ini file.
 
+        :return: None
         """
         with open(self.settings_file, 'w') as fid:
             fid.writelines(DAX_SETTINGS_TEMPLATE.format(**self.settings_dict))
 
     def config(self):
-        """
-        Caller for all of the _get* methods
-        :return: None
+        """Caller for all of the _get* methods.
 
+        :return: True if using default settings, False otherwise
         """
-        print 'Starting to config the dax_settings.ini file:'
-        print '\n  ADMIN :'
-        self._get_user_home()
-        self._get_admin_email()
-        self._get_smtp_from()
-        self._get_smtp_host()
-        self._get_smtp_pass()
-        self._get_xsitype_include()
-        print '\n  CLUSTER :'
-        use_default = self._use_cluster_default()
-        if use_default:
-            self._set_cluster_default()
+        self._set_dax_setup_type()
+        if self.dax_setup_type == 'cluster':
+            print 'Starting to config the dax_settings.ini file:'
+            print '\n  ADMIN :'
+            self._get_user_home()
+            self._get_admin_email()
+            self._get_smtp_from()
+            self._get_smtp_host()
+            self._get_smtp_pass()
+            self._get_xsitype_include()
+            print '\n  CLUSTER :'
+            use_default = self._use_cluster_default()
+            if use_default:
+                self._set_cluster_default()
+            else:
+                self._get_cmd_submit()
+                self._get_prefix_jobid()
+                self._get_suffix_jobid()
+                self._get_cmd_count_nb_jobs()
+                self._get_cmd_get_job_status()
+                self._get_queue_status()
+                self._get_running_status()
+                self._get_complete_status()
+                self._get_cmd_get_job_memory()
+                self._get_cmd_get_job_walltime()
+                self._get_cmd_get_job_node()
+                self._get_job_extension_file()
+                self._get_job_template()
+                self._get_email_opts()
+                self._get_gateway()
+                self._get_root_job_dir()
+                self._get_queue_limit()
+                self._get_results_dir()
+                self._get_max_age()
+                self._get_launcher_type()
+            print '\n  REDCAP :'
+            self._get_api_url()
+            self._get_api_key_dax()
+            self._get_dax_manager_dict()
         else:
-            self._get_cmd_submit()
-            self._get_prefix_jobid()
-            self._get_suffix_jobid()
-            self._get_cmd_count_nb_jobs()
-            self._get_cmd_get_job_status()
-            self._get_queue_status()
-            self._get_running_status()
-            self._get_complete_status()
-            self._get_cmd_get_job_memory()
-            self._get_cmd_get_job_walltime()
-            self._get_cmd_get_job_node()
-            self._get_job_extension_file()
-            self._get_job_template()
-            self._get_email_opts()
-            self._get_gateway()
-            self._get_root_job_dir()
-            self._get_queue_limit()
-            self._get_results_dir()
-            self._get_max_age()
-            self._get_launcher_type()
-            
-        print '\n  REDCAP :'
-        self._get_api_url()
-        self._get_api_key_dax()
-        self._get_dax_manager_dict()
+            self._set_tools_setup()
+
+
+def init_profile():
+    """Function to init your profile file to call xnat_profile.
+
+    :param profile_path: path to your profile file
+    :return: None
+    """
+    # link the file in the bashrc or profile
+    profile = os.path.join(os.path.expanduser('~'), '.bash_profile')
+
+    if os.path.exists(os.path.join(os.path.expanduser('~'), '.bash_profile')):
+        profile = os.path.join(os.path.expanduser('~'), '.bash_profile')
+    elif os.path.exists(os.path.join(os.path.expanduser('~'), '.bashrc')):
+        profile = os.path.join(os.path.expanduser('~'), '.bashrc')
+    elif os.path.exists(os.path.join(os.path.expanduser('~'), '.profile')):
+        profile = os.path.join(os.path.expanduser('~'), '.profile')
+    else:
+        raise Exception("could not find your profile file. Please set up XNAT_HOST, \
+XNAT_USER, and XNAT_PASS environment variables manually and rerun dax_setup.")
+    # Add the line to the profile
+    if 'source ~/.xnat_profile' not in open(profile).read():
+        with open(profile, "a") as f_profile:
+            f_profile.write(BASH_PROFILE_XNAT)
 
 if __name__ == '__main__':
     print '########## DAX_SETUP ##########'
-    print 'Script to setup the ~/.dax_settings.ini files for your dax installation.\n'
+    print 'Script to setup the ~/.dax_settings.ini files \
+for your dax installation.\n'
     DSH = DAX_Setup_Handler()
 
     DSH.config()
     DSH.write()
+
+    print '\n0 error(s) -- dax_setup done.'
+    print '########## END ##########'

--- a/bin/dax_tools/dax_setup
+++ b/bin/dax_tools/dax_setup
@@ -598,29 +598,6 @@ copied to for upload.", default, is_path=True)
         value = self._prompt("Please max days before re-running dax_build \
 on a session.", '7')
         self._set('max_age', value)
-        
-    def _get_launcher_type(self):
-        """
-        Prompt the user to choose a launcher type
-
-        :return: None
-
-        """
-        value2type = {'1':'xnatq-combined',
-                      '2':'diskq-combined',
-                      '3':'diskq-xnat',
-                      '4':'diskq-cluster'}
-        
-        msg = "Which launcher type do you want to use? ["
-        for v,t in value2type.iteritems():
-            msg += v+'.'+t+' '
-        
-        msg = msg[:-1]+"]"
-        value = '0'
-        while value not in ['1', '2', '3', '4']:
-            value = self._prompt(msg, '1')
-
-        self._set('launcher_type', value2type[value])
 
     # redcap section
     def _get_api_url(self):
@@ -855,6 +832,28 @@ cluster use.\n         Wiki: https://github.com/VUIIS/dax/wiki/DAX-Set-up"""
         else:
             self._set_tools_setup()
 
+    def _get_launcher_type(self):
+        """
+        Prompt the user to choose a launcher type
+
+        :return: None
+
+        """
+        value2type = {'1':'xnatq-combined',
+                      '2':'diskq-combined',
+                      '3':'diskq-xnat',
+                      '4':'diskq-cluster'}
+        
+        msg = "Which launcher type do you want to use? ["
+        for v,t in value2type.iteritems():
+            msg += v+'.'+t+' '
+        
+        msg = msg[:-1]+"]"
+        value = '0'
+        while value not in ['1', '2', '3', '4']:
+            value = self._prompt(msg, '1')
+
+        self._set('launcher_type', value2type[value])
 
 def init_profile():
     """Function to init your profile file to call xnat_profile.

--- a/bin/dax_tools/dax_setup
+++ b/bin/dax_tools/dax_setup
@@ -46,6 +46,7 @@ root_job_dir={root_job_dir}
 queue_limit={queue_limit}
 results_dir={results_dir}
 max_age={max_age}
+launcher_type={launcher_type}
 
 ; Information used to connect to REDCap databases if DAX_manager is used
 [redcap]
@@ -544,6 +545,29 @@ class DAX_Setup_Handler(object):
         """
         value = self._prompt("Please max days before re-running dax_build on a session.", '7')
         self._set('max_age', value)
+        
+    def _get_launcher_type(self):
+        """
+        Prompt the user to choose a launcher type
+
+        :return: None
+
+        """
+        value2type = {'1':'xnatq-combined',
+                      '2':'diskq-combined',
+                      '3':'diskq-xnat',
+                      '4':'diskq-cluster'}
+        
+        msg = "Which launcher type do you want to use? ["
+        for v,t in value2type.iteritems():
+            msg += v+'.'+t+' '
+        
+        msg = msg[:-1]+"]"
+        value = '0'
+        while value not in ['1', '2', '3', '4']:
+            value = self._prompt(msg, '1')
+
+        self._set('launcher_type', value2type[value])
 
     # redcap section
     def _get_api_url(self):
@@ -665,6 +689,7 @@ class DAX_Setup_Handler(object):
         self._get_queue_limit()
         self._get_results_dir()
         self._get_max_age()
+        self._get_launcher_type()
 
     def write(self):
         """
@@ -713,6 +738,8 @@ class DAX_Setup_Handler(object):
             self._get_queue_limit()
             self._get_results_dir()
             self._get_max_age()
+            self._get_launcher_type()
+            
         print '\n  REDCAP :'
         self._get_api_url()
         self._get_api_key_dax()

--- a/bin/dax_tools/dax_setup
+++ b/bin/dax_tools/dax_setup
@@ -71,7 +71,6 @@ root_job_dir={root_job_dir}
 queue_limit={queue_limit}
 results_dir={results_dir}
 max_age={max_age}
-launcher_type={launcher_type}
 
 ; Information used to connect to REDCap databases if DAX_manager is used.
 [redcap]
@@ -710,7 +709,6 @@ file from DAX? [yes/no] ")
             self._get_queue_limit()
             self._get_results_dir()
             self._get_max_age()
-            self._get_launcher_type()
 
         if cluster_type == '1':
             cluster_dict = DEFAULT_SGE_DICT
@@ -824,7 +822,6 @@ cluster use.\n         Wiki: https://github.com/VUIIS/dax/wiki/DAX-Set-up"""
                 self._get_queue_limit()
                 self._get_results_dir()
                 self._get_max_age()
-                self._get_launcher_type()
             print '\n  REDCAP :'
             self._get_api_url()
             self._get_api_key_dax()
@@ -832,28 +829,6 @@ cluster use.\n         Wiki: https://github.com/VUIIS/dax/wiki/DAX-Set-up"""
         else:
             self._set_tools_setup()
 
-    def _get_launcher_type(self):
-        """
-        Prompt the user to choose a launcher type
-
-        :return: None
-
-        """
-        value2type = {'1':'xnatq-combined',
-                      '2':'diskq-combined',
-                      '3':'diskq-xnat',
-                      '4':'diskq-cluster'}
-        
-        msg = "Which launcher type do you want to use? ["
-        for v,t in value2type.iteritems():
-            msg += v+'.'+t+' '
-        
-        msg = msg[:-1]+"]"
-        value = '0'
-        while value not in ['1', '2', '3', '4']:
-            value = self._prompt(msg, '1')
-
-        self._set('launcher_type', value2type[value])
 
 def init_profile():
     """Function to init your profile file to call xnat_profile.

--- a/bin/dax_tools/dax_upload
+++ b/bin/dax_tools/dax_upload
@@ -437,24 +437,28 @@ def upload_assessor(xnat, assessor_dict):
                 upload_resource(assessor_obj, resource, resource_path)
 
         ## after Upload ##
-        if os.path.exists(os.path.join(assessor_dict['path'], _READY_FLAG_FILE)):
-            if is_diskq_assessor(assessor_dict['label']): # was this run using the DISKQ option
-                # Read attributes
-                ctask = ClusterTask(assessor_dict['label'], RESULTS_DIR, DISKQ_DIR)
-                assessor_obj.attrs.mset({
-                    xsitype + '/procstatus': COMPLETE,
-                    xsitype + '/validation/status': NEEDS_QA,
-                    xsitype + '/jobid': ctask.get_jobid(),
-                    xsitype + '/jobnode': ctask.get_jobnode(),
-                    xsitype + '/memused': ctask.get_memused(),
-                    xsitype + '/walltimeused': ctask.get_walltime(),
-                    xsitype + '/jobstartdate': ctask.get_jobstartdate()
-                })
-                ctask.delete()
-            else:
-                assessor_obj.attrs.set(xsitype + '/procstatus', READY_TO_COMPLETE)
+        if is_diskq_assessor(assessor_dict['label']): # was this run using the DISKQ option
+            # Read attributes
+            ctask = ClusterTask(assessor_dict['label'], RESULTS_DIR, DISKQ_DIR)
+            
+            # Set on XNAT
+            assessor_obj.attrs.mset({
+                xsitype + '/procstatus': ctask.get_status(),
+                xsitype + '/validation/status': NEEDS_QA,
+                xsitype + '/jobid': ctask.get_jobid(),
+                xsitype + '/jobnode': ctask.get_jobnode(),
+                xsitype + '/memused': ctask.get_memused(),
+                xsitype + '/walltimeused': ctask.get_walltime(),
+                xsitype + '/jobstartdate': ctask.get_jobstartdate()
+            })
+            
+            # Delete the task from diskq
+            ctask.delete()
+        elif os.path.exists(os.path.join(assessor_dict['path'], _READY_FLAG_FILE)):
+            assessor_obj.attrs.set(xsitype + '/procstatus', READY_TO_COMPLETE)
         else:
             assessor_obj.attrs.set(xsitype+'/procstatus', JOB_FAILED)
+            
         #Remove the folder
         shutil.rmtree(assessor_dict['path'])
 

--- a/bin/dax_tools/dax_upload
+++ b/bin/dax_tools/dax_upload
@@ -16,11 +16,16 @@ from datetime import datetime
 from email.mime.text import MIMEText
 
 from dax import XnatUtils, DAX_Settings
-from dax.task import READY_TO_COMPLETE, COMPLETE, UPLOADING, JOB_FAILED, JOB_PENDING
+from dax.task import READY_TO_COMPLETE, COMPLETE, UPLOADING, JOB_FAILED, JOB_PENDING, NEEDS_QA
+from dax.task import ClusterTask
 
 ########### VARIABLES ###########
 DAX_SETTINGS = DAX_Settings()
 RESULTS_DIR = DAX_SETTINGS.get_results_dir()
+JOB_EXTENSION_FILE = DAX_SETTINGS.get_job_extension_file()
+DISKQ_DIR = os.path.join(RESULTS_DIR, 'DISKQ')
+DISKQ_BATCH_DIR = os.path.join(DISKQ_DIR, 'BATCH')
+_COMPLETE_FLAG_FILE = 'READY_TO_COMPLETE.txt'
 SMTP_FROM = DAX_SETTINGS.get_smtp_from()
 SMTP_HOST = DAX_SETTINGS.get_smtp_host()
 SMTP_PASS = DAX_SETTINGS.get_smtp_pass()
@@ -205,8 +210,9 @@ def get_assessor_list(projects):
             continue
         if os.path.exists(os.path.join(assessor_path, _EMAILED_FLAG_FILE)):
             continue
-        if os.path.exists(os.path.join(assessor_path, _READY_FLAG_FILE)) or\
-           os.path.exists(os.path.join(assessor_path, _FAILED_FLAG_FILE)):
+        if (os.path.exists(os.path.join(assessor_path, _READY_FLAG_FILE)) or\
+           os.path.exists(os.path.join(assessor_path, _FAILED_FLAG_FILE))) and\
+           (not is_diskq_assessor(assessor_label) or os.path.exists(os.path.join(assessor_path, _COMPLETE_FLAG_FILE))):
             # Passed all checks, so add it to upload list
             assessor_label_list.append(assessor_label)
 
@@ -398,7 +404,7 @@ def upload_assessor(xnat, assessor_dict):
                                        assessor_dict['session_label'])
     if not session_obj.exists():
         LOGGER.error('Cannot upload assessor, session does not exist.')
-        return
+        return True
 
     #Select assessor
     assessor_obj = session_obj.assessor(assessor_dict['label'])
@@ -432,11 +438,28 @@ def upload_assessor(xnat, assessor_dict):
 
         ## after Upload ##
         if os.path.exists(os.path.join(assessor_dict['path'], _READY_FLAG_FILE)):
-            assessor_obj.attrs.set(xsitype+'/procstatus', READY_TO_COMPLETE)
+            if is_diskq_assessor(assessor_dict['label']): # was this run using the DISKQ option
+                # Read attributes
+                ctask = ClusterTask(assessor_dict['label'], RESULTS_DIR, DISKQ_DIR)
+                assessor_obj.attrs.mset({
+                    xsitype + '/procstatus': COMPLETE,
+                    xsitype + '/validation/status': NEEDS_QA,
+                    xsitype + '/jobid': ctask.get_jobid(),
+                    xsitype + '/jobnode': ctask.get_jobnode(),
+                    xsitype + '/memused': ctask.get_memused(),
+                    xsitype + '/walltimeused': ctask.get_walltime(),
+                    xsitype + '/jobstartdate': ctask.get_jobstartdate()
+                })
+            else:
+                assessor_obj.attrs.set(xsitype + '/procstatus', READY_TO_COMPLETE)
         else:
             assessor_obj.attrs.set(xsitype+'/procstatus', JOB_FAILED)
         #Remove the folder
         shutil.rmtree(assessor_dict['path'])
+
+def is_diskq_assessor(assr_label):
+    # Does a batch file exist for this assessor?
+    return os.path.exists(os.path.join(DISKQ_BATCH_DIR, assr_label + JOB_EXTENSION_FILE))
 
 def upload_resource(assessor_obj, resource, resource_path):
     """
@@ -753,7 +776,7 @@ if __name__ == '__main__':
     WARNING_LIST = list()
     #Logger for logs
     LOGGER = dax.bin.set_logger(OPTIONS.logfile, OPTIONS.debug)
-    LOGGER.info('Time at the beginning of the Process_Upload: '+ str(datetime.now())+'\n')
+    LOGGER.info('Time at the beginning of the Process_Upload: '+str(datetime.now())+'\n')
     #Check if folders exist
     check_folders()
     DAX_UPLOAD_FLAGFILE = "%s%s.txt" % (FLAGFILE_TEMPLATE, OPTIONS.suffix)

--- a/bin/dax_tools/dax_upload
+++ b/bin/dax_tools/dax_upload
@@ -450,6 +450,7 @@ def upload_assessor(xnat, assessor_dict):
                     xsitype + '/walltimeused': ctask.get_walltime(),
                     xsitype + '/jobstartdate': ctask.get_jobstartdate()
                 })
+                ctask.delete()
             else:
                 assessor_obj.attrs.set(xsitype + '/procstatus', READY_TO_COMPLETE)
         else:

--- a/dax/XnatUtils.py
+++ b/dax/XnatUtils.py
@@ -77,8 +77,9 @@ A_RESOURCES_URI  = '/REST/projects/{project}/subjects/{subject}/experiments/{ses
 A_RESOURCE_URI   = '/REST/projects/{project}/subjects/{subject}/experiments/{session}/assessors/{assessor}/out/resources/{resource}'
 
 # List post URI variables:
-SUBJECT_POST_URI = '''?columns=ID,project,label,URI,last_modified,src,handedness,gender,yob'''
+SUBJECT_POST_URI = '''?columns=ID,project,label,URI,last_modified,src,handedness,gender,yob,dob'''
 SESSION_POST_URI = '''?xsiType={stype}&columns=ID,URI,subject_label,subject_ID,modality,project,date,xsiType,{stype}/age,label,{stype}/meta/last_modified,{stype}/original'''
+NO_MOD_SESSION_POST_URI = '''?xsiType={stype}&columns=ID,URI,subject_label,subject_ID,project,date,xsiType,{stype}/age,label,{stype}/meta/last_modified,{stype}/original'''
 SCAN_POST_URI = '''?columns=ID,URI,label,subject_label,project,xnat:imagesessiondata/scans/scan/id,xnat:imagesessiondata/scans/scan/type,xnat:imagesessiondata/scans/scan/quality,xnat:imagesessiondata/scans/scan/note,xnat:imagesessiondata/scans/scan/frames,xnat:imagesessiondata/scans/scan/series_description,xnat:imagesessiondata/subject_id'''
 SCAN_PROJ_POST_URI = '''?project={project}&xsiType=xnat:imageSessionData&columns=ID,URI,label,subject_label,project,xnat:imagesessiondata/subject_id,xnat:imagescandata/id,xnat:imagescandata/type,xnat:imagescandata/quality,xnat:imagescandata/note,xnat:imagescandata/frames,xnat:imagescandata/series_description,xnat:imagescandata/file/label'''
 SCAN_PROJ_INCLUDED_POST_URI = '''?xnat:imagesessiondata/sharing/share/project={project}&xsiType=xnat:imageSessionData&columns=ID,URI,label,subject_label,project,xnat:imagesessiondata/subject_id,xnat:imagescandata/id,xnat:imagescandata/type,xnat:imagescandata/quality,xnat:imagescandata/note,xnat:imagescandata/frames,xnat:imagescandata/series_description,xnat:imagescandata/file/label'''
@@ -628,11 +629,14 @@ def list_sessions(intf, projectid=None, subjectid=None):
 
     #Get the subjects list to get the subject ID:
     subj_list = list_subjects(intf, projectid)
-    subj_id2lab = dict((subj['ID'], [subj['handedness'], subj['gender'], subj['yob']]) for subj in subj_list)
+    subj_id2lab = dict((subj['ID'], [subj['handedness'], subj['gender'], subj['yob'], subj['dob']]) for subj in subj_list)
 
     # Get list of sessions for each type since we have to specific about last_modified field
     for sess_type in type_list:
-        post_uri_type = post_uri + SESSION_POST_URI.format(stype=sess_type)
+        if sess_type.startswith('xnat:') and 'session' in sess_type:
+            post_uri_type = post_uri + SESSION_POST_URI.format(stype=sess_type)
+        else:
+            post_uri_type = post_uri + NO_MOD_SESSION_POST_URI.format(stype=sess_type)
         sess_list = intf._get_json(post_uri_type)
 
         for sess in sess_list:
@@ -645,14 +649,19 @@ def list_sessions(intf, projectid=None, subjectid=None):
             sess['subject_id'] = sess['subject_ID']
             sess['session_id'] = sess['ID']
             sess['session_label'] = sess['label']
-            sess['session_type'] = sess_type.split('xnat:')[1].split('session')[0].upper()
-            sess['type'] = sess_type.split('xnat:')[1].split('session')[0].upper()
-            sess['last_modified'] = sess[sess_type+'/meta/last_modified']
-            sess['last_updated'] = sess[sess_type+'/original']
-            sess['age'] = sess[sess_type+'/age']
+            if sess_type.startswith('xnat:') and 'session' in sess_type:
+                sess['session_type'] = sess_type.split('xnat:')[1].split('session')[0].upper()
+                sess['type'] = sess_type.split('xnat:')[1].split('session')[0].upper()
+            else:
+                sess['session_type'] = sess_type
+                sess['type'] = sess_type
+            sess['last_modified'] = sess.get(sess_type+'/meta/last_modified', None)
+            sess['last_updated'] = sess.get(sess_type+'/original', None)
+            sess['age'] = sess.get(sess_type+'/age', None)
             sess['handedness'] = subj_id2lab[sess['subject_ID']][0]
             sess['gender'] = subj_id2lab[sess['subject_ID']][1]
             sess['yob'] = subj_id2lab[sess['subject_ID']][2]
+            sess['dob'] = subj_id2lab[sess['subject_ID']][3]
 
         # Add sessions of this type to full list
         full_sess_list.extend(sess_list)
@@ -1423,13 +1432,13 @@ def is_bad_qa(qcstatus):
     Check to see if the QA status of an assessor is bad (aka unusable)
 
     :param qcstatus: String of the QC status of the assessor
-    :return: True if bad, False if not bad
+    :return: -1 if bad, 1 if not bad, 0 if still in progress (NOTE: doesn't follow boolean logic)
 
     """
-    if qcstatus in [task.JOB_PENDING, task.NEEDS_QA, task.REPROC]:
+    if qcstatus in [task.JOB_PENDING, task.NEEDS_QA, task.REPROC, task.FAILED_NEEDS_REPROC]:
         return 0
     for qc in task.BAD_QA_STATUS:
-        if qc in qcstatus.split(' ')[0].lower():
+        if qc.lower() in qcstatus.split(' ')[0].lower():
             return -1
     return 1
 

--- a/dax/XnatUtils.py
+++ b/dax/XnatUtils.py
@@ -2319,6 +2319,16 @@ class CachedImageSession():
         self.sess_element = ET.fromstring(xml_str)
         self.project = proj
         self.subject = subj
+        self.xnat = xnat # cache for later usage
+        self.session = sess
+
+    def reload(self):
+        proj = self.project
+        subj = self.subject
+        sess = self.session
+        sess_uri = '/project/' + proj + '/subject/' + subj + '/experiment/' + sess
+        xml_str = self.xnat.select(sess_uri).get()
+        self.sess_element = ET.fromstring(xml_str)
 
     def label(self):
         """
@@ -2443,6 +2453,15 @@ class CachedImageSession():
 
         """
         return [res.info() for res in self.resources()]
+
+    def full_object(self):
+        """
+        Return a the full pyxnat Session object of this sessions
+
+        :return: pyxnat Session object
+
+        """
+        return get_full_object(self.xnat, self.info())
 
 class CachedImageScan():
     """

--- a/dax/bin.py
+++ b/dax/bin.py
@@ -61,7 +61,7 @@ def launch_jobs(settings_path, logfile, debug, projects=None, sessions=None, wri
     settings.myLauncher.launch_jobs(lockfile_prefix, projects, sessions, writeonly, pbsdir)
     logger.info('finished update, End Time: '+str(datetime.now()))
 
-def build(settings_path, logfile, debug, projects=None, sessions=None):
+def build(settings_path, logfile, debug, projects=None, sessions=None, mod_delta=None):
     """
     Method that is responsible for running all modules and putting assessors
      into the database
@@ -86,7 +86,7 @@ def build(settings_path, logfile, debug, projects=None, sessions=None):
 
     # Run the updates
     logger.info('running build, Start Time:'+str(datetime.now()))
-    settings.myLauncher.build(lockfile_prefix, projects, sessions)
+    settings.myLauncher.build(lockfile_prefix, projects, sessions, mod_delta=mod_delta)
     logger.info('finished build, End Time: '+str(datetime.now()))
 
 def update_tasks(settings_path, logfile, debug, projects=None, sessions=None):

--- a/dax/bin.py
+++ b/dax/bin.py
@@ -69,8 +69,8 @@ def build(settings_path, logfile, debug, projects=None, sessions=None):
     :param settings_path: Path to the project settings file
     :param logfile: Full file of the file used to log to
     :param debug: Should debug mode be used
-    :param projects: Project(s) that need to be launched
-    :param sessions: Session(s) that need to be updated
+    :param projects: Project(s) that need to be built
+    :param sessions: Session(s) that need to be built
     :return: None
 
     """
@@ -85,9 +85,9 @@ def build(settings_path, logfile, debug, projects=None, sessions=None):
     lockfile_prefix = os.path.splitext(os.path.basename(settings_path))[0]
 
     # Run the updates
-    logger.info('running update, Start Time:'+str(datetime.now()))
+    logger.info('running build, Start Time:'+str(datetime.now()))
     settings.myLauncher.build(lockfile_prefix, projects, sessions)
-    logger.info('finished update, End Time: '+str(datetime.now()))
+    logger.info('finished build, End Time: '+str(datetime.now()))
 
 def update_tasks(settings_path, logfile, debug, projects=None, sessions=None):
     """

--- a/dax/cluster.py
+++ b/dax/cluster.py
@@ -292,6 +292,27 @@ class PBS:   #The script file generator class
 
         return jobid.strip()
 
+def submit_job(filename):
+    """
+    Submit the file to the cluster
+    :return: jobid
+    """
+    try:
+        cmd = CMD_SUBMIT + ' ' + filename
+        proc = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output, error = proc.communicate()
+        if output:
+            LOGGER.info(output)
+        if error:
+            LOGGER.error(error)
+        # output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+        jobid = get_specific_str(output, PREFIX_JOBID, SUFFIX_JOBID)
+    except CalledProcessError as err:
+        LOGGER.error(err)
+        jobid = '0'
+
+    return jobid.strip()
+
 class ClusterLaunchException(Exception):
     """Custom exception raised when launch on the grid failed"""
     def __init__(self):

--- a/dax/dax_settings.ini
+++ b/dax/dax_settings.ini
@@ -28,6 +28,7 @@ root_job_dir=/tmp
 queue_limit=600
 results_dir=~/RESULTS_XNAT_SPIDER
 max_age=7
+launcher_type=xnatq-combined
 
 ; Information used to connect to REDCap databases if DAX_manager is used
 [redcap]

--- a/dax/dax_settings.py
+++ b/dax/dax_settings.py
@@ -461,6 +461,15 @@ class DAX_Settings(object):
 
         """
         return int(self.get('cluster', 'max_age'))
+    
+    def get_launcher_type(self):
+        """
+        Get the launcher type from the cluster
+
+        :return: String of the launcher type: xnatq-combined, diskq-xnat, diskq-cluster
+
+        """
+        return self.get('cluster', 'launcher_type')
 
     # redcap section
     def get_api_url(self):

--- a/dax/dax_settings.py
+++ b/dax/dax_settings.py
@@ -15,7 +15,8 @@ class DAX_Settings(object):
         if not os.path.isfile(ini_settings_file):
             sys.stderr.write('ERROR: file %s not found\n' % ini_settings_file)
             sys.stderr.write('Please run dax_setup\n')
-            sys.exit(1)
+            #sys.exit(1)
+            ini_settings_file = os.path.abspath('./dax_settings.ini')
 
         self.ini_settings_file = ini_settings_file
         self.config_parser = ConfigParser.ConfigParser(allow_no_value=True)

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -83,7 +83,7 @@ class Launcher(object):
         self.launcher_type = launcher_type
 
         # Creating Folders for flagfile/pbs/outlog in RESULTS_DIR
-        if launcher_type in ['diskq-xnat', 'diskq-cluster']:
+        if launcher_type in ['diskq-xnat', 'diskq-cluster', 'diskq-combined']:
             check_dir(DISKQ_DIR)
             check_dir(DISKQ_INPUTS_DIR)
             check_dir(DISKQ_OUTLOG_DIR)
@@ -150,7 +150,7 @@ class Launcher(object):
         project_list = self.init_script(flagfile, project_local, type_update=3, start_end=1)
 
         try:
-            if self.launcher_type == 'diskq-cluster':
+            if self.launcher_type in ['diskq-cluster', 'diskq-combined']:
                 LOGGER.info('Loading task queue from:' + DISKQ_DIR)
                 task_list = load_task_queue(status=task.NEED_TO_RUN)
 
@@ -221,7 +221,7 @@ class Launcher(object):
                 mes_format = """  +Launching job:{label}, currently {count} jobs in cluster queue"""
                 LOGGER.info(mes_format.format(label=cur_task.assessor_label,
                                               count=str(cur_job_count)))
-            if self.launcher_type == 'diskq-cluster':
+            if self.launcher_type in ['diskq-cluster', 'diskq-combined']:
                 success = cur_task.launch()
             else:
                 success = cur_task.launch(self.root_job_dir, self.job_email, self.job_email_options, self.xnat_host, writeonly, pbsdir)
@@ -259,7 +259,7 @@ class Launcher(object):
         project_list = self.init_script(flagfile, project_local, type_update=2, start_end=1)
 
         try:
-            if self.launcher_type == 'diskq-cluster':
+            if self.launcher_type in ['diskq-cluster', 'diskq-combined']:
                 LOGGER.info('Loading task queue from:' + DISKQ_DIR)
                 task_list = load_task_queue()
 
@@ -473,7 +473,7 @@ class Launcher(object):
                     proc_assr = assr
                     break
 
-            if self.launcher_type == 'diskq-xnat':
+            if self.launcher_type in ['diskq-xnat', 'diskq-combined']:
                 if proc_assr == None or proc_assr.info()['procstatus'] == task.NEED_INPUTS:
                     assessor = csess.full_object().assessor(assr_name)
                     xtask = XnatTask(sess_proc, assessor, RESULTS_DIR, DISKQ_DIR)
@@ -550,7 +550,7 @@ class Launcher(object):
                 if assr.info()['label'] == assr_name:
                     proc_assr = assr
 
-            if self.launcher_type == 'diskq-xnat':
+            if self.launcher_type in ['diskq-xnat', 'diskq-combined']:
                 if proc_assr == None or proc_assr.info()['procstatus'] == task.NEED_INPUTS:
                     # TODO: get session object directly
                     scan = XnatUtils.get_full_object(xnat, scan_info)

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -15,13 +15,14 @@ import XnatUtils
 import task
 import cluster
 import bin
-from task import Task
+from task import Task, ClusterTask, XnatTask
 from dax_settings import DAX_Settings
 DAX_SETTINGS = DAX_Settings()
 RESULTS_DIR = DAX_SETTINGS.get_results_dir()
 DEFAULT_ROOT_JOB_DIR = DAX_SETTINGS.get_root_job_dir()
 DEFAULT_QUEUE_LIMIT = DAX_SETTINGS.get_queue_limit()
 DEFAULT_MAX_AGE = DAX_SETTINGS.get_max_age()
+DEFAULT_LAUNCHER_TYPE = DAX_SETTINGS.get_launcher_type()
 
 UPDATE_PREFIX = 'updated--'
 UPDATE_FORMAT = "%Y-%m-%d %H:%M:%S"
@@ -32,12 +33,29 @@ LAUNCH_SUFFIX = 'LAUNCHER_RUNNING.txt'
 #Logger to print logs
 LOGGER = logging.getLogger('dax')
 
+FLAG_DIR = os.path.join(RESULTS_DIR, 'FlagFiles')
+OUTLOG_DIR = os.path.join(RESULTS_DIR, 'OUTLOG')
+BATCH_DIR = os.path.join(RESULTS_DIR, 'PBS')
+
+DISKQ_DIR = os.path.join(RESULTS_DIR, 'DISKQ')
+DISKQ_BATCH_DIR = os.path.join(DISKQ_DIR, 'BATCH')
+DISKQ_OUTLOG_DIR = os.path.join(DISKQ_DIR, 'OUTLOG')
+DISKQ_INPUTS_DIR = os.path.join(DISKQ_DIR, 'INPUTS')
+
+def check_dir(dir_path):
+    try:
+        os.makedirs(dir_path)
+    except OSError:
+        if not os.path.isdir(dir_path):
+            raise
+
 class Launcher(object):
     """ Launcher object to manage a list of projects from a settings file """
     def __init__(self, project_process_dict, project_modules_dict, priority_project=None,
                  queue_limit=DEFAULT_QUEUE_LIMIT, root_job_dir=DEFAULT_ROOT_JOB_DIR,
                  xnat_user=None, xnat_pass=None, xnat_host=None,
-                 job_email=None, job_email_options='bae', max_age=DEFAULT_MAX_AGE):
+                 job_email=None, job_email_options='bae', max_age=DEFAULT_MAX_AGE, 
+                 launcher_type=DEFAULT_LAUNCHER_TYPE):
         """
         Entry point for the Launcher class
 
@@ -62,16 +80,20 @@ class Launcher(object):
         self.job_email = job_email
         self.job_email_options = job_email_options
         self.max_age = max_age
+        self.launcher_type = launcher_type
 
-        #Creating Folders for flagfile/pbs/outlog in RESULTS_DIR
-        if not os.path.exists(RESULTS_DIR):
-            os.mkdir(RESULTS_DIR)
-        if not os.path.exists(os.path.join(RESULTS_DIR, 'PBS')):
-            os.mkdir(os.path.join(RESULTS_DIR, 'PBS'))
-        if not os.path.exists(os.path.join(RESULTS_DIR, 'OUTLOG')):
-            os.mkdir(os.path.join(RESULTS_DIR, 'OUTLOG'))
-        if not os.path.exists(os.path.join(RESULTS_DIR, 'FlagFiles')):
-            os.mkdir(os.path.join(RESULTS_DIR, 'FlagFiles'))
+        # Creating Folders for flagfile/pbs/outlog in RESULTS_DIR
+        if launcher_type in ['diskq-xnat', 'diskq-cluster']:
+            check_dir(DISKQ_DIR)
+            check_dir(DISKQ_INPUTS_DIR)
+            check_dir(DISKQ_OUTLOG_DIR)
+            check_dir(DISKQ_BATCH_DIR)
+            check_dir(FLAG_DIR)
+        else:
+            check_dir(RESULTS_DIR)
+            check_dir(FLAG_DIR)
+            check_dir(OUTLOG_DIR)
+            check_dir(BATCH_DIR)
 
         # Add empty lists for projects in one list but not the other
         for proj in self.project_process_dict.keys():
@@ -116,29 +138,41 @@ class Launcher(object):
         :return: None
 
         """
-        LOGGER.info('-------------- Launch Tasks --------------\n')
+        if self.launcher_type == 'diskq-xnat':
+            LOGGER.error('cannot launch jobs with this launcher type:' + self.launcher_type)
+            return
 
-        flagfile = os.path.join(RESULTS_DIR, 'FlagFiles', lockfile_prefix+'_'+LAUNCH_SUFFIX)
+        LOGGER.info('-------------- Launch Tasks --------------\n')
+        LOGGER.info('launcher_type = '+self.launcher_type)
+
+        xnat = None
+        flagfile = os.path.join(FLAG_DIR, lockfile_prefix + '_' + LAUNCH_SUFFIX)
         project_list = self.init_script(flagfile, project_local, type_update=3, start_end=1)
 
         try:
-            LOGGER.info('Connecting to XNAT at '+self.xnat_host)
-            xnat = XnatUtils.get_interface(self.xnat_host, self.xnat_user, self.xnat_pass)
+            if self.launcher_type == 'diskq-cluster':
+                LOGGER.info('Loading task queue from:' + DISKQ_DIR)
+                task_list = load_task_queue(status=task.NEED_TO_RUN)
 
-            if not XnatUtils.has_dax_datatypes(xnat):
-                raise Exception('error: dax datatypes are not installed on your xnat <%s>' % (self.xnat_host))
+                LOGGER.info(str(len(task_list)) + ' tasks that need to be launched found')
+                self.launch_tasks(task_list)
+            else:
+                LOGGER.info('Connecting to XNAT at ' + self.xnat_host)
+                xnat = XnatUtils.get_interface(self.xnat_host, self.xnat_user, self.xnat_pass)
 
-            LOGGER.info('Getting launchable tasks list...')
-            task_list = self.get_tasks(xnat,
-                                       self.is_launchable_tasks,
-                                       project_list,
-                                       sessions_local)
+                if not XnatUtils.has_dax_datatypes(xnat):
+                    raise Exception('error: dax datatypes are not installed on your xnat <%s>' % (self.xnat_host))
 
-            LOGGER.info(str(len(task_list))+' tasks that need to be launched found')
+                LOGGER.info('Getting launchable tasks list...')
+                task_list = self.get_tasks(xnat,
+                                           self.is_launchable_tasks,
+                                           project_list,
+                                           sessions_local)
 
-            #Launch the task that need to be launch
-            self.launch_tasks(task_list, writeonly, pbsdir)
+                LOGGER.info(str(len(task_list))+' tasks that need to be launched found')
 
+                # Launch the task that need to be launch
+                self.launch_tasks(task_list, writeonly, pbsdir)
         finally:
             self.finish_script(xnat, flagfile, project_list, 3, 2, project_local)
 
@@ -187,7 +221,11 @@ class Launcher(object):
                 mes_format = """  +Launching job:{label}, currently {count} jobs in cluster queue"""
                 LOGGER.info(mes_format.format(label=cur_task.assessor_label,
                                               count=str(cur_job_count)))
-            success = cur_task.launch(self.root_job_dir, self.job_email, self.job_email_options, self.xnat_host, writeonly, pbsdir)
+            if self.launcher_type == 'diskq-cluster':
+                success = cur_task.launch()
+            else:
+                success = cur_task.launch(self.root_job_dir, self.job_email, self.job_email_options, self.xnat_host, writeonly, pbsdir)
+
             if not success:
                 LOGGER.error('ERROR:failed to launch job')
                 raise cluster.ClusterLaunchException
@@ -209,31 +247,47 @@ class Launcher(object):
         :return: None
 
         """
-        LOGGER.info('-------------- Update Tasks --------------\n')
+        if self.launcher_type == 'diskq-xnat':
+            LOGGER.error('cannot update jobs with this launcher type:' + self.launcher_type)
+            return
 
-        flagfile = os.path.join(RESULTS_DIR, 'FlagFiles', lockfile_prefix+'_'+UPDATE_SUFFIX)
+        LOGGER.info('-------------- Update Tasks --------------\n')
+        LOGGER.info('launcher_type = '+self.launcher_type)
+
+        xnat = None
+        flagfile = os.path.join(FLAG_DIR, lockfile_prefix + '_' + UPDATE_SUFFIX)
         project_list = self.init_script(flagfile, project_local, type_update=2, start_end=1)
 
         try:
-            LOGGER.info('Connecting to XNAT at '+self.xnat_host)
-            xnat = XnatUtils.get_interface(self.xnat_host, self.xnat_user, self.xnat_pass)
+            if self.launcher_type == 'diskq-cluster':
+                LOGGER.info('Loading task queue from:' + DISKQ_DIR)
+                task_list = load_task_queue()
 
-            if not XnatUtils.has_dax_datatypes(xnat):
-                raise Exception('error: dax datatypes are not installed on your xnat <%s>' % (self.xnat_host))
+                LOGGER.info(str(len(task_list)) + ' tasks found.')
 
-            LOGGER.info('Getting task list...')
-            task_list = self.get_tasks(xnat,
-                                       self.is_updatable_tasks,
-                                       project_list,
-                                       sessions_local)
+                LOGGER.info('Updating tasks...')
+                for cur_task in task_list:
+                    LOGGER.info('Updating task:' + cur_task.assessor_label)
+                    cur_task.update_status()
+            else:
+                LOGGER.info('Connecting to XNAT at ' + self.xnat_host)
+                xnat = XnatUtils.get_interface(self.xnat_host, self.xnat_user, self.xnat_pass)
 
-            LOGGER.info(str(len(task_list))+' open tasks found')
+                if not XnatUtils.has_dax_datatypes(xnat):
+                    raise Exception('error: dax datatypes are not installed on your xnat <%s>' % (self.xnat_host))
 
-            LOGGER.info('Updating tasks...')
-            for cur_task in task_list:
-                LOGGER.info('     Updating task:'+cur_task.assessor_label)
-                cur_task.update_status()
+                LOGGER.info('Getting task list...')
+                task_list = self.get_tasks(xnat,
+                                           self.is_updatable_tasks,
+                                           project_list,
+                                           sessions_local)
 
+                LOGGER.info(str(len(task_list))+' open tasks found')
+
+                LOGGER.info('Updating tasks...')
+                for cur_task in task_list:
+                    LOGGER.info('     Updating task:' + cur_task.assessor_label)
+                    cur_task.update_status()
         finally:
             self.finish_script(xnat, flagfile, project_list, 2, 2, project_local)
 
@@ -261,9 +315,15 @@ class Launcher(object):
         :return: None
 
         """
-        LOGGER.info('-------------- Build --------------\n')
+        if self.launcher_type == 'diskq-cluster':
+            LOGGER.error('cannot build jobs with this launcher type:' + self.launcher_type)
+            return
 
-        flagfile = os.path.join(RESULTS_DIR, 'FlagFiles', lockfile_prefix+'_'+BUILD_SUFFIX)
+        LOGGER.info('-------------- Build --------------\n')
+        LOGGER.info('launcher_type = '+self.launcher_type)
+
+
+        flagfile = os.path.join(FLAG_DIR, lockfile_prefix + '_' + BUILD_SUFFIX)
         project_list = self.init_script(flagfile, project_local, type_update=1, start_end=1)
 
         try:
@@ -306,6 +366,9 @@ class Launcher(object):
         # Get lists of modules/processors per scan/exp for this project
         exp_mods, scan_mods = modules.modules_by_type(self.project_modules_dict[project_id])
         exp_procs, scan_procs = processors.processors_by_type(self.project_process_dict[project_id])
+        #proj_settings = self.proj_settings_dict[project_id]
+        #use_lastupdate = proj_settings.use_lastupdate
+        use_lastupdate = False
 
         # Check for new processors
         has_new = self.has_new_processors(xnat, project_id, exp_procs, scan_procs)
@@ -315,30 +378,27 @@ class Launcher(object):
 
         # Update each session from the list:
         for sess_info in sessions:
-            last_mod = datetime.strptime(sess_info['last_modified'][0:19], UPDATE_FORMAT)
-            now_date = datetime.today()
-            last_up = self.get_lastupdated(sess_info)
+            if use_lastupdate and not has_new and not sessions_local:
+                last_mod = datetime.strptime(sess_info['last_modified'][0:19], UPDATE_FORMAT)
+                now_date = datetime.today()
+                last_up = self.get_lastupdated(sess_info)
+                if last_up != None and \
+                    last_mod < last_up and \
+                    now_date < last_mod + timedelta(days=int(self.max_age)):
+                    mess = """  +Session:{sess}: skipping, last_mod={mod},last_up={up}"""
+                    mess_str = mess.format(sess=sess_info['label'], mod=str(last_mod), up=str(last_up))
+                    LOGGER.info(mess_str)
+                    continue
 
-            #If sessions_local is set, skip checking the date
-            if not has_new and last_up != None and \
-               last_mod < last_up and not sessions_local and \
-               now_date < last_mod+timedelta(days=int(self.max_age)):
-                mess = """  +Session:{sess}: skipping, last_mod={mod},last_up={up}"""
-                mess_str = mess.format(sess=sess_info['label'], mod=str(last_mod), up=str(last_up))
-                LOGGER.info(mess_str)
-            else:
-                update_run_count = 0
-                got_updated = False
-                while update_run_count < 3 and not got_updated:
-                    mess = """  +Session:{sess}: updating (count:{count})..."""
-                    LOGGER.info(mess.format(sess=sess_info['label'], count=update_run_count))
-                    # NOTE: we keep the starting time of the update
-                    # and will check if something change during the update
-                    update_start_time = datetime.now()
-                    self.build_session(xnat, sess_info, exp_procs, scan_procs, exp_mods, scan_mods)
-                    got_updated = self.set_session_lastupdated(xnat, sess_info, update_start_time)
-                    update_run_count = update_run_count+1
-                    LOGGER.debug('\n')
+            mess = """  +Session:{sess}: building..."""
+            LOGGER.info(mess.format(sess=sess_info['label']))
+
+            if use_lastupdate:
+                update_start_time = datetime.now()
+
+            self.build_session(xnat, sess_info, exp_procs, scan_procs, exp_mods, scan_mods)
+            if use_lastupdate:
+                self.set_session_lastupdated(xnat, sess_info, update_start_time)
 
         if not sessions_local or sessions_local.lower() == 'all':
             # Modules after run
@@ -365,38 +425,70 @@ class Launcher(object):
         session_info = csess.info()
         sess_obj = None
 
-        # Modules on session
-        LOGGER.debug('== Build modules for session ==')
-        for sess_mod in sess_mod_list:
-            LOGGER.debug('* Module: '+sess_mod.getname())
-            if sess_mod.needs_run(csess, xnat):
-                if sess_obj == None:
-                    sess_obj = XnatUtils.get_full_object(xnat, session_info)
+        # Modules
+        mod_count = 0
+        while mod_count < 3:
+            mess = """== Build modules (count:{count}) =="""
+            LOGGER.debug(mess.format(count=mod_count))
+            # NOTE: we keep starting time to check if something changes below
+            start_time = datetime.now()
+            if sess_mod_list:
+                self.build_session_modules(xnat, csess, sess_mod_list)
+            if scan_mod_list:
+                for cscan in csess.scans():
+                    LOGGER.debug('+SCAN: ' + cscan.info()['scan_id'])
+                    self.build_scan_modules(xnat, cscan, scan_mod_list)
 
-                sess_mod.run(session_info, sess_obj)
+            if not sess_was_modified(xnat, sess_info, start_time):
+                break
 
-        # Scans
-        LOGGER.debug('== Build modules/processors for scans in session ==')
-        if scan_proc_list or scan_mod_list:
+            csess.reload()
+            mod_count += 1
+
+        # Scan Processors
+        LOGGER.debug('== Build scan processors ==')
+        if scan_proc_list:
             for cscan in csess.scans():
-                LOGGER.debug('+SCAN: '+cscan.info()['scan_id'])
-                self.build_scan(xnat, cscan, scan_proc_list, scan_mod_list)
+                LOGGER.debug('+SCAN: ' + cscan.info()['scan_id'])
+                self.build_scan_processors(xnat, cscan, scan_proc_list)
 
-        # Processors
-        LOGGER.debug('== Build processors for session ==')
+        # Session Processors
+        LOGGER.debug('== Build session processors ==')
+        if sess_proc_list:
+            self.build_session_processors(xnat, csess, sess_proc_list)
+
+    def build_session_processors(self, xnat, csess, sess_proc_list):
+        sess_info = csess.info()
+
         for sess_proc in sess_proc_list:
-            if sess_proc.should_run(session_info):
+            if not sess_proc.should_run(sess_info):
+                continue
 
-                assr_name = sess_proc.get_assessor_name(csess)
+            assr_name = sess_proc.get_assessor_name(csess)
 
-                # Look for existing assessor
-                proc_assr = None
-                for assr in csess.assessors():
-                    if assr.info()['label'] == assr_name:
-                        proc_assr = assr
+            # Look for existing assessor
+            proc_assr = None
+            for assr in csess.assessors():
+                if assr.info()['label'] == assr_name:
+                    proc_assr = assr
+                    break
 
+            if self.launcher_type == 'diskq-xnat':
                 if proc_assr == None or proc_assr.info()['procstatus'] == task.NEED_INPUTS:
-                    # Create it if it doesn't exist
+                    assessor = csess.full_object().assessor(assr_name)
+                    xtask = XnatTask(sess_proc, assessor, RESULTS_DIR, DISKQ_DIR)
+                    LOGGER.debug('building task:' + assr_name)
+                    (proc_status, qc_status) = xtask.build_task(
+                        csess,
+                        self.root_job_dir,
+                        self.job_email,
+                        self.job_email_options)
+                    LOGGER.debug('proc_status=' + proc_status + ', qc_status=' + qc_status)
+                else:
+                    # TODO: check that it actually exists in QUEUE
+                    LOGGER.debug('skipping, already built:' + assr_name)
+            else:
+                if proc_assr == None or proc_assr.info()['procstatus'] == task.NEED_INPUTS:
                     sess_task = sess_proc.get_task(xnat, csess, RESULTS_DIR)
                     self.log_updating_status(sess_proc.name, sess_task.assessor_label)
                     has_inputs, qcstatus = sess_proc.has_inputs(csess)
@@ -408,24 +500,32 @@ class Launcher(object):
                         sess_task.set_qcstatus(qcstatus)
                     else:
                         sess_task.set_qcstatus(qcstatus)
+
                 else:
                     # Other statuses handled by dax_update_tasks
                     pass
 
-    @staticmethod
-    def log_updating_status(procname, assessor_label):
+    def build_session_modules(self, xnat, csess, sess_mod_list):
         """
-        Print as debug the status updating string
+        Build a session
 
-        :param procname: process name
-        :param assessors_label: assessor label
+        :param xnat: pyxnat.Interface object
+        :param sess_info: python ditionary from XnatUtils.list_sessions method
+        :param sess_mod_list: list of modules running on a session
         :return: None
         """
-        mess = """* Processor:{proc}: updating status: {label}"""
-        mess_str = mess.format(proc=procname, label=assessor_label)
-        LOGGER.debug(mess_str)
 
-    def build_scan(self, xnat, cscan, scan_proc_list, scan_mod_list):
+        sess_obj = None
+        sess_info = csess.info()
+        for sess_mod in sess_mod_list:
+            LOGGER.debug('* Module: ' + sess_mod.getname())
+            if sess_mod.needs_run(csess, xnat):
+                if sess_obj == None:
+                    sess_obj = csess.full_object()
+
+                sess_mod.run(sess_info, sess_obj)
+
+    def build_scan_processors(self, xnat, cscan, scan_proc_list):
         """
         Build the scan
 
@@ -436,29 +536,37 @@ class Launcher(object):
         :return: None
         """
         scan_info = cscan.info()
-        scan_obj = None
-
-        # Modules
-        for scan_mod in scan_mod_list:
-            LOGGER.debug('* Module: '+scan_mod.getname())
-            if scan_mod.needs_run(cscan, xnat):
-                if scan_obj == None:
-                    scan_obj = XnatUtils.get_full_object(xnat, scan_info)
-
-                scan_mod.run(scan_info, scan_obj)
 
         # Processors
         for scan_proc in scan_proc_list:
-            if scan_proc.should_run(scan_info):
-                assr_name = scan_proc.get_assessor_name(cscan)
+            if not scan_proc.should_run(scan_info):
+                continue
 
-                # Look for existing assessor
-                proc_assr = None
-                for assr in cscan.parent().assessors():
-                    if assr.info()['label'] == assr_name:
-                        proc_assr = assr
+            assr_name = scan_proc.get_assessor_name(cscan)
 
-                # Create it if it doesn't exist
+            # Look for existing assessor
+            proc_assr = None
+            for assr in cscan.parent().assessors():
+                if assr.info()['label'] == assr_name:
+                    proc_assr = assr
+
+            if self.launcher_type == 'diskq-xnat':
+                if proc_assr == None or proc_assr.info()['procstatus'] == task.NEED_INPUTS:
+                    # TODO: get session object directly
+                    scan = XnatUtils.get_full_object(xnat, scan_info)
+                    assessor = scan.parent().assessor(assr_name)
+                    xtask = XnatTask(scan_proc, assessor, RESULTS_DIR, DISKQ_DIR)
+                    LOGGER.debug('building task:' + assr_name)
+                    (proc_status, qc_status) = xtask.build_task(
+                        cscan,
+                        self.root_job_dir,
+                        self.job_email,
+                        self.job_email_options)
+                    LOGGER.debug('proc_status=' + proc_status + ', qc_status=' + qc_status)
+                else:
+                    # TODO: check that it actually exists in QUEUE
+                    LOGGER.debug('skipping, already built:' + assr_name)
+            else:
                 if proc_assr == None or proc_assr.info()['procstatus'] == task.NEED_INPUTS:
                     scan_task = scan_proc.get_task(xnat, cscan, RESULTS_DIR)
                     self.log_updating_status(scan_proc.name, scan_task.assessor_label)
@@ -474,6 +582,21 @@ class Launcher(object):
                 else:
                     # Other statuses handled by dax_update_open_tasks
                     pass
+
+
+    def build_scan_modules(self, xnat, cscan, scan_mod_list):
+
+        scan_info = cscan.info()
+        scan_obj = None
+
+        # Modules
+        for scan_mod in scan_mod_list:
+            LOGGER.debug('* Module: ' + scan_mod.getname())
+            if scan_mod.needs_run(cscan, xnat):
+                if scan_obj == None:
+                    scan_obj = XnatUtils.get_full_object(xnat, scan_info)
+
+                scan_mod.run(scan_info, scan_obj)
 
     def module_prerun(self, project_id, settings_filename=''):
         """
@@ -556,8 +679,10 @@ The project is not part of the settings."""
             self.unlock_flagfile(flagfile)
             #Set the date on REDCAP for update ending
             bin.upload_update_date_redcap(project_list, type_update, start_end)
-        xnat.disconnect()
-        LOGGER.info('Connection to XNAT closed')
+            
+        if xnat:
+            xnat.disconnect()
+            LOGGER.info('Connection to XNAT closed')
 
     @staticmethod
     def lock_flagfile(lock_file):
@@ -779,14 +904,14 @@ The project is not part of the settings."""
         last_mod = datetime.strptime(last_modified_xnat[0:19], '%Y-%m-%d %H:%M:%S')
         if last_mod > update_start_time:
             return False
-        else:
-            #format:
-            update_str = (datetime.now()+timedelta(minutes=1)).strftime(UPDATE_FORMAT)
-            # We set update to one minute into the future
-            # since setting update field will change last modified time
-            LOGGER.debug('setting last_updated for:'+sess_info['label']+' to '+update_str)
-            sess_obj.attrs.set(xsi_type+'/original', UPDATE_PREFIX+update_str)
-            return True
+
+        # format:
+        update_str = (datetime.now()+timedelta(minutes=1)).strftime(UPDATE_FORMAT)
+        # We set update to one minute into the future
+        # since setting update field will change last modified time
+        LOGGER.debug('setting last_updated for:' + sess_info['label'] + ' to ' + update_str)
+        sess_obj.attrs.set(xsi_type + '/original', UPDATE_PREFIX + update_str)
+        return True
 
     @staticmethod
     def has_new_processors(xnat, project_id, sess_proc_list, scan_proc_list):
@@ -811,3 +936,39 @@ The project is not part of the settings."""
 
         # Are there any?
         return len(diff_list) > 0
+
+def load_task_queue(status=None):
+    task_list = list()
+
+    for t in os.listdir(DISKQ_BATCH_DIR):
+        # task_path = os.path.join(BATCH_DIR, t)
+
+        LOGGER.debug('loading:' + t)
+        task = ClusterTask(os.path.splitext(t)[0], RESULTS_DIR, DISKQ_DIR)
+        LOGGER.debug('status = ' + task.get_status())
+
+        # TODO:filter based on project, subject, session, type
+        if not status or task.get_status() == status:
+            LOGGER.debug('adding task to list:' + t)
+            task_list.append(task)
+
+    return task_list
+
+def get_sess_lastmod(xnat, sess_info):
+    xsi_type = sess_info['xsiType']
+    sess_obj = XnatUtils.get_full_object(xnat, sess_info)
+    last_modified_xnat = sess_obj.attrs.get(xsi_type + '/meta/last_modified')
+    last_mod = datetime.strptime(last_modified_xnat[0:19], '%Y-%m-%d %H:%M:%S')
+    return last_mod
+
+def sess_was_modified(xnat, sess_info, build_start_time):
+    """
+    Compare modified time with start time
+    :param xnat: pyxnat.Interface object
+    :param sess_info: dictionary of session information
+    :param update_start_time: date when the update started
+    :return: False if the session change and don't set the last update date, True otherwise
+    """
+    last_mod = get_sess_lastmod(xnat, sess_info)
+    return (last_mod > build_start_time)
+

--- a/dax/processors.py
+++ b/dax/processors.py
@@ -127,6 +127,15 @@ class Processor(object):
         """
         raise NotImplementedError()
 
+    def build_cmds(self, cobj, dir):
+
+        """
+        Build the commands that will go in the PBS/SLURM script
+        :raises: NotImplementedError if not overridden from base class.
+        :return: None
+        """
+        raise NotImplementedError()
+
 class ScanProcessor(Processor):
     """ Scan Processor class for processor on a scan on XNAT """
     def __init__(self, scan_types, walltime_str, memreq_mb, spider_path, version=None, ppn=1, suffix_proc=''):

--- a/dax/task.py
+++ b/dax/task.py
@@ -92,7 +92,11 @@ class Task(object):
 
         # Create assessor if needed
         if not assessor.exists():
-            assessor.create(assessors=self.atype)
+            if self.atype == 'fs:fsdata':
+                assessor.create(assessors='fs:fsData', **{'fs:fsData/fsversion':'0'})       
+            else:
+                assessor.create(assessors=self.atype)
+            
             self.set_createdate_today()
             atype = self.atype.lower()
             if atype == 'proc:genprocdata':

--- a/dax/task.py
+++ b/dax/task.py
@@ -1468,6 +1468,5 @@ class XnatTask(Task):
             elif has_inputs == -1:
                 raise NoDataException(qcstatus)
             else:
-                sess_task.set_qcstatus(qcstatus)
                 raise NeedInputsException(qcstatus)
     

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,8 +16,6 @@ import sys
 import os
 import io
 sys.path.insert(0, os.path.abspath('..'))
-import dax
-import dax.task
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ Packaging for dax
 
 import os
 from setuptools import setup, find_packages
+import shutil
 
 def get_version():
     basedir = os.path.dirname(__file__)
@@ -22,6 +23,10 @@ def readme():
         return f.read()
 
 if __name__ == '__main__':
+    #Address a sphinx issue
+    shutil.copy('dax/dax_settings.ini',
+                os.path.join(os.path.expanduser('~'), '.dax_settings.ini'))
+
     setup(name='dax',
           version=get_version(),
           description='Distributed Automation for XNAT',
@@ -43,7 +48,6 @@ if __name__ == '__main__':
                    'bin/dax_tools/dax_upload',
                    'bin/dax_tools/run_spider',
                    'bin/dax_tools/dax_setup',
-                   'bin/dax_tools/dax_test',
                    'bin/dax_tools/GenerateModuleTemplate',
                    'bin/dax_tools/GenerateProcessorTemplate',
                    'bin/dax_tools/GenerateSpiderTemplate',
@@ -91,3 +95,4 @@ if __name__ == '__main__':
                        "Topic :: Scientific/Engineering :: Information Analysis",
                        ],
           )
+


### PR DESCRIPTION
Hello! This branch adds an alternate way to manage tasks/jobs using files on disk instead of XNAT. The goal is to minimize the interactions with XNAT to track the state of open jobs. When a new task is ready, the batch (or PBS) file is immediately written to disk. From that point until upload, XNAT is not needed.

In addition, this allows DAX to run in a situation where the only communication between XNAT and the cluster is via a shared filesystem. On the system with access to XNAT, you'd set the launcher_type to diskq-xnat and only run dax_build and dax_upload. Then on the system with access to the cluster, you would set the launcher_type to diskq-cluster and only run dax_update_tasks and dax_launch.  This should be helpful to @MattVUIIS. Note that we still need to implement a way to pre-download inputs.

And lastly, a modification to the behavior of Processors is included. The new function build_cmds() can replace the pair of existing functions has_inputs() and get_cmds(). When build_cmds() is called it should either return the commands to be run in the Batch or raise an exception. The exception should either be NeedInputsException or NoDataException. The contents of the exception should be the reason. This in effect performs the same function as has_inputs(). We are basically combining has_inputs() and get_cmds() in a way that asks for forgiveness rather than permission. Note that the old way is still supported if build_cmds() is not implemented by a processor.

P.S. 
While coding this, I realized that some major refactoring would be beneficial. What we have now has evolved into a bit of a mess. I decided to leave the mess and integrate this functionality into the existing structure, so it is easier to switch between the old way and this new way.
