### PR TITLE
bug fix for baxter

### DIFF
--- a/dax/dax_settings.py
+++ b/dax/dax_settings.py
@@ -493,7 +493,11 @@ class DAX_Settings(object):
 
         :return: String of the results_dir value, None if empty
         """
-        return self.get('cluster', 'results_dir')
+        resultsdir = self.get('cluster', 'results_dir')
+        if resultsdir.startswith('~'):
+            return os.path.expanduser('~') + resultsdir[1:]
+        else:
+            return resultsdir
 
     def get_max_age(self):
         """Get the max_age value from the cluster section.

--- a/dax/dax_settings.py
+++ b/dax/dax_settings.py
@@ -495,7 +495,7 @@ class DAX_Settings(object):
         """
         resultsdir = self.get('cluster', 'results_dir')
         if resultsdir.startswith('~'):
-            return os.path.expanduser('~') + resultsdir[1:]
+            return os.path.join(os.path.expanduser('~'),resultsdir[2:])
         else:
             return resultsdir
 


### PR DESCRIPTION
Slight bugfix for get_results_dir. Strips off ~ if it exists and replaces it with os.path.expanduser('~') 