### PR TITLE
148 double assrs

### DIFF
--- a/bin/Xnat_tools/XnatSwitchProcessStatus
+++ b/bin/Xnat_tools/XnatSwitchProcessStatus
@@ -344,18 +344,18 @@ def set_proc_status(assessor_obj, status, username='NULL',
     :param xsitype: datatype to change status
     :return: None
     """
-    assessor_obj.attrs.set(xsitype+'/procstatus', status)
+    assessor_obj.attrs.set(xsitype + '/procstatus', status)
     if status == task.NEED_INPUTS or status == task.NEED_TO_RUN:
-        assessor_obj.attrs.mset({xsitype+'/validation/status': 'Job Pending',
-                                 xsitype+'/jobid': 'NULL',
-                                 xsitype+'/memused': 'NULL',
-                                 xsitype+'/walltimeused': 'NULL',
-                                 xsitype+'/jobnode': 'NULL',
-                                 xsitype+'/jobstartdate': 'NULL',
-                                 xsitype+'/validation/validated_by': 'NULL',
-                                 xsitype+'/validation/date': 'NULL',
-                                 xsitype+'/validation/notes': 'NULL',
-                                 xsitype+'/validation/method': 'NULL'})
+        assessor_obj.attrs.mset({xsitype + '/validation/status': 'Job Pending',
+                                 xsitype + '/jobid': 'NULL',
+                                 xsitype + '/memused': 'NULL',
+                                 xsitype + '/walltimeused': 'NULL',
+                                 xsitype + '/jobnode': 'NULL',
+                                 xsitype + '/jobstartdate': 'NULL',
+                                 xsitype + '/validation/validated_by': 'NULL',
+                                 xsitype + '/validation/date': 'NULL',
+                                 xsitype + '/validation/notes': 'NULL',
+                                 xsitype + '/validation/method': 'NULL'})
     sys.stdout.write('   - Job Status on Assessor %s changed to %s\n'
                      % (assessor_obj.label(), status))
     if status == task.COMPLETE:
@@ -602,14 +602,14 @@ the assessors from -t you changed are inputs to those assessors."
                         action="store_true", help=_h)
     parser.add_argument("--fullRegex", dest="full_regex", action='store_true',
                         help="Use full regex for filtering data.")
-    _h = "Restart the assessors which mean switching status to NEED_TO_RUN \
-and delete previous resources."
+    _h = "Restart the assessors by switching the status for all assessors \
+found to NEED_TO_RUN and delete previous resources."
     parser.add_argument("--restart", dest="restart", action='store_true',
                         help=_h)
-    _h = "Rerun the assessors meaning switching sttus to NEED_TO_RUN for \
+    _h = "Rerun the assessors by switching status to NEED_TO_RUN for \
 assessors that failed and delete previous resources."
     parser.add_argument("--rerun", dest="rerun", action='store_true', help=_h)
-    _h = "Init the assessors meaning switching status to NEED_INPUTS for \
+    _h = "Init the assessors by switching status to NEED_INPUTS for \
 assessors that have been set to NO_DATA."
     parser.add_argument("--init", dest="init", action='store_true', help=_h)
     return parser

--- a/dax/XnatUtils.py
+++ b/dax/XnatUtils.py
@@ -2832,6 +2832,17 @@ class CachedImageSession():
 
         return ''
 
+    def has_shared_project(self):
+        """
+        Get the project if shared.
+
+        :return: project_shared_id if shared, None otherwise
+        """
+        project_id = self.sess_element.get('project')
+        if project_id != self.project:
+            return project_id
+        return None
+
     def scans(self):
         """
         Get a list of CachedImageScan objects for the XNAT session

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -598,14 +598,7 @@ cluster queue"
             if not sess_proc.should_run(sess_info):
                 continue
 
-            assr_name = sess_proc.get_assessor_name(csess)
-
-            # Look for existing assessor
-            p_assr = None
-            for assr in csess.assessors():
-                if assr.info()['label'] == assr_name:
-                    p_assr = assr
-                    break
+            p_assr, assr_name = sess_proc.get_assessor(csess)
 
             if self.launcher_type in ['diskq-xnat', 'diskq-combined']:
                 if p_assr is None or \
@@ -701,13 +694,7 @@ setting assessor status'
             if not scan_proc.should_run(scan_info):
                 continue
 
-            assr_name = scan_proc.get_assessor_name(cscan)
-
-            # Look for existing assessor
-            p_assr = None
-            for assr in cscan.parent().assessors():
-                if assr.info()['label'] == assr_name:
-                    p_assr = assr
+            p_assr, assr_name = scan_proc.get_assessor(cscan)
 
             if self.launcher_type in ['diskq-xnat', 'diskq-combined']:
                 if p_assr is None or \

--- a/dax/processors.py
+++ b/dax/processors.py
@@ -186,7 +186,7 @@ class ScanProcessor(Processor):
         """
         raise NotImplementedError()
 
-    def get_assessor(self, cscan):
+    def get_assessor_name(self, cscan):
         """
         Returns the label of the assessor
 
@@ -211,19 +211,36 @@ class ScanProcessor(Processor):
                                            scan_label, self.name])
 
         # Look for existing assessor
-        p_assr = None
         assr_label = assr_name
         for assr in csess.assessors():
             if assr_name_shared is not None and \
                assr.info()['label'] == assr_name_shared:
-                p_assr = assr
                 assr_label = assr_name_shared
                 break
             if assr.info()['label'] == assr_name:
+                break
+
+        return assr_label
+
+    def get_assessor(self, cscan):
+        """
+        Returns the assessor object depending on cscan and the assessor label.
+
+        :param cscan: CachedImageScan object from XnatUtils
+        :return: String of the assessor label
+
+        """
+        assessor_name = self.get_assessor_name(cscan)
+
+        # Look for existing assessor
+        csess = cscan.parent()
+        p_assr = None
+        for assr in csess.assessors():
+            if assr.info()['label'] == assessor_name:
                 p_assr = assr
                 break
 
-        return p_assr, assr_label
+        return p_assr, assessor_name
 
     def get_task(self, intf, cscan, upload_dir):
         """
@@ -237,7 +254,7 @@ class ScanProcessor(Processor):
 
         """
         scan_dict = cscan.info()
-        _, assessor_name = self.get_assessor(cscan)
+        assessor_name = self.get_assessor_name(cscan)
         scan = XnatUtils.get_full_object(intf, scan_dict)
         assessor = scan.parent().assessor(assessor_name)
         return task.Task(self, assessor, upload_dir)
@@ -301,11 +318,11 @@ class SessionProcessor(Processor):
         """
         return True
 
-    def get_assessor(self, csess):
+    def get_assessor_name(self, csess):
         """
-        Get the name of the assessor
+        Returns the label of the assessor
 
-        :param csess: CachedImageSession from XnatUtils
+        :param csess: CachedImageSession object from XnatUtils
         :return: String of the assessor label
 
         """
@@ -323,19 +340,35 @@ class SessionProcessor(Processor):
                                            self.name])
 
         # Look for existing assessor
-        p_assr = None
         assr_label = assr_name
         for assr in csess.assessors():
             if assr_name_shared is not None and \
                assr.info()['label'] == assr_name_shared:
-                p_assr = assr
                 assr_label = assr_name_shared
                 break
             if assr.info()['label'] == assr_name:
+                break
+
+        return assr_label
+
+    def get_assessor(self, csess):
+        """
+        Returns the assessor object depending on csess and the assessor label.
+
+        :param csess: CachedImageSession object from XnatUtils
+        :return: String of the assessor label
+
+        """
+        assessor_name = self.get_assessor_name(csess)
+
+        # Look for existing assessor
+        p_assr = None
+        for assr in csess.assessors():
+            if assr.info()['label'] == assessor_name:
                 p_assr = assr
                 break
 
-        return p_assr, assr_label
+        return p_assr, assessor_name
 
     def get_task(self, intf, csess, upload_dir):
         """
@@ -348,7 +381,7 @@ class SessionProcessor(Processor):
 
         """
         sess_info = csess.info()
-        _, assessor_name = self.get_assessor(csess)
+        assessor_name = self.get_assessor_name(csess)
         session = XnatUtils.get_full_object(intf, sess_info)
         assessor = session.assessor(assessor_name)
         return task.Task(self, assessor, upload_dir)

--- a/dax/processors.py
+++ b/dax/processors.py
@@ -236,7 +236,10 @@ class ScanProcessor(Processor):
         :return: Task object
 
         """
-        assessor, _ = self.get_assessor(cscan)
+        scan_dict = cscan.info()
+        _, assessor_name = self.get_assessor(cscan)
+        scan = XnatUtils.get_full_object(intf, scan_dict)
+        assessor = scan.parent().assessor(assessor_name)
         return task.Task(self, assessor, upload_dir)
 
     def should_run(self, scan_dict):
@@ -344,7 +347,10 @@ class SessionProcessor(Processor):
         :return: Task object of the assessor
 
         """
-        assessor, _ = self.get_assessor(csess)
+        sess_info = csess.info()
+        _, assessor_name = self.get_assessor(csess)
+        session = XnatUtils.get_full_object(intf, sess_info)
+        assessor = session.assessor(assessor_name)
         return task.Task(self, assessor, upload_dir)
 
 

--- a/dax/processors.py
+++ b/dax/processors.py
@@ -214,13 +214,13 @@ class ScanProcessor(Processor):
         p_assr = None
         assr_label = assr_name
         for assr in csess.assessors():
-            if assr.info()['label'] == assr_name:
-                p_assr = assr
-                break
             if assr_name_shared is not None and \
                assr.info()['label'] == assr_name_shared:
                 p_assr = assr
                 assr_label = assr_name_shared
+                break
+            if assr.info()['label'] == assr_name:
+                p_assr = assr
                 break
 
         return p_assr, assr_label
@@ -326,13 +326,13 @@ class SessionProcessor(Processor):
         p_assr = None
         assr_label = assr_name
         for assr in csess.assessors():
-            if assr.info()['label'] == assr_name:
-                p_assr = assr
-                break
             if assr_name_shared is not None and \
                assr.info()['label'] == assr_name_shared:
                 p_assr = assr
                 assr_label = assr_name_shared
+                break
+            if assr.info()['label'] == assr_name:
+                p_assr = assr
                 break
 
         return p_assr, assr_label

--- a/dax/processors.py
+++ b/dax/processors.py
@@ -206,7 +206,7 @@ class ScanProcessor(Processor):
         csess = cscan.parent()
         proj_shared = csess.has_shared_project()
         assr_name_shared = None
-        if proj_shared:
+        if proj_shared is not None:
             assr_name_shared = '-x-'.join([proj_shared, subj_label, sess_label,
                                            scan_label, self.name])
 
@@ -318,7 +318,7 @@ class SessionProcessor(Processor):
         # Check if shared project:
         proj_shared = csess.has_shared_project()
         assr_name_shared = None
-        if proj_shared:
+        if proj_shared is not None:
             assr_name_shared = '-x-'.join([proj_shared, subj_label, sess_label,
                                            self.name])
 

--- a/dax/task.py
+++ b/dax/task.py
@@ -130,7 +130,8 @@ class Task(object):
         if not assessor.exists():
             if self.atype == DEFAULT_FS_DATATYPE.lower():
                 kwargs = {'%s/fsversion' % DEFAULT_FS_DATATYPE.lower(): '0'}
-                assessor.create(assessors=DEFAULT_FS_DATATYPE.lower(), **kwargs)
+                assessor.create(assessors=DEFAULT_FS_DATATYPE.lower(),
+                                **kwargs)
             else:
                 assessor.create(assessors=self.atype)
 
@@ -188,11 +189,11 @@ class Task(object):
         """
         atype = self.atype
         mgets = self.assessor.attrs.mget([
-                         '%s/memused' % atype,
-                         '%s/walltimeused' % atype,
-                         '%s/jobid' % atype,
-                         '%s/jobnode' % atype,
-                         '%s/jobstartdate' % atype
+            '%s/memused' % atype,
+            '%s/walltimeused' % atype,
+            '%s/jobid' % atype,
+            '%s/jobnode' % atype,
+            '%s/jobstartdate' % atype
         ])
         return [mgets[0].strip(),
                 mgets[1].strip(),


### PR DESCRIPTION
Hi guys,

I have been working on fixing an issue that I discovered last week. If with DAX, you process two projects where one of them has shared data from the other one, it will duplicate all the assessors because the name of the project is different. (see issue 148 for more explanation)

I fixed it by adding a has_project_shared in CachedImageSession object. I edited the processors to return the p_assr and the assessor label with the function get_assessor(). In this function, if the main project as an assessor with the right name, I return this assessor label instead of the one with the shared project name so it skipped the session that comes from the main project when there is an assessor that exists.

I tested it and it works fine. 

Kind Regards,

Ben 