### PR TITLE
First addition of XNAT CR compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Gedit backup files
+*.py~
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/dax/XnatUtils.py
+++ b/dax/XnatUtils.py
@@ -2213,7 +2213,7 @@ def upload_file_to_obj(filepath, resource_obj, remove=False, removeall=False,
                 print("WARNING: upload_file_to_obj in XnatUtils: resource %s \
 already exists." % filename)
                 return False
-        resource_obj.file(str(filename)).put(str(filepath), overwrite=True)
+        resource_obj.file(str(filename)).put(str(filepath), overwrite=True, params={"event_reason": "DAX uploading file"})
         return True
 
 

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -73,7 +73,7 @@ class Launcher(object):
                  priority_project=None,
                  queue_limit=DAX_SETTINGS.get_queue_limit(),
                  root_job_dir=DAX_SETTINGS.get_root_job_dir(),
-                 xnat_user=None, xnat_pass=None, xnat_host=None,
+                 xnat_user=None, xnat_pass=None, xnat_host=None, cr=None,
                  job_email=None, job_email_options='bae', max_age=7,
                  launcher_type=DAX_SETTINGS.get_launcher_type(),
                  skip_lastupdate=None):
@@ -87,6 +87,7 @@ class Launcher(object):
         :param queue_limit: maximum number of jobs in the queue
         :param root_job_dir: root directory for jobs
         :param xnat_host: XNAT Host url. By default, use env variable.
+        :param cr: True if the host is an XNAT CR instance (will default to False if not specified)
         :param xnat_user: XNAT User ID. By default, use env variable.
         :param xnat_pass: XNAT Password. By default, use env variable.
         :param job_email: job email address for report
@@ -166,6 +167,15 @@ name as a key and list of yaml filepaths as values.'
         self.xnat_host = xnat_host
         if not self.xnat_host:
             self.xnat_host = os.environ['XNAT_HOST']
+
+        # CR flag: don't want something like 'cr: blah blah' in the settings file turning the cr flag on
+        if str(cr).upper()=='TRUE': 
+            self.cr=True
+        else:
+            self.cr=False
+
+        LOGGER.info('XNAT CR status: cr=%s, self.cr=%s'%(str(cr),str(self.cr)))
+    
         # User:
         if not xnat_user:
             netrc_obj = DAX_Netrc()
@@ -563,7 +573,7 @@ cluster queue"
 
             try:
                 if not self.skip_lastupdate:
-                    self.set_session_lastupdated(xnat, sess_info,
+                    self.set_session_lastupdated(xnat, self.cr, sess_info,
                                                  update_start_time)
             except Exception as E:
                 err1 = 'Caught exception setting session timestamp %s'
@@ -1144,11 +1154,12 @@ The project is not part of the settings."""
             return datetime.strptime(update_time, UPDATE_FORMAT)
 
     @staticmethod
-    def set_session_lastupdated(xnat, sess_info, update_start_time):
+    def set_session_lastupdated(xnat, cr, sess_info, update_start_time):
         """
         Set the last session update on XNAT
 
         :param xnat: pyxnat.Interface object
+        :param cr: True if the host is an XNAT CR instance
         :param sess_info: dictionary of session information
         :param update_start_time: date when the update started
         :return: False if the session change(don't set the last update date),
@@ -1171,8 +1182,11 @@ The project is not part of the settings."""
         deg = 'setting last_updated for: %s to %s'
         LOGGER.debug(deg % (sess_info['label'], update_str))
         try:
-            sess_obj.attrs.set('%s/original' % xsi_type,
-                               UPDATE_PREFIX + update_str)
+            if cr:
+                LOGGER.critical('CR does not seem to allow changing of session timestamp, what do we do?')
+            else:
+                sess_obj.attrs.set('%s/original' % xsi_type,
+                               UPDATE_PREFIX + update_str, params={"event_reason": "DAX setting session_lastupdated"})
         except Exception as E:
             err1 = 'Caught exception setting update timestamp for session %s'
             err2 = 'Exception class %s caught with message %s'


### PR DESCRIPTION
Dear All,
This commit introduces some preliminary changes for XNAT CR compatibility. However, it will require the latest version of pyXNAT.

Tim Olsen of NRG states "event reason is included in XNAT itself.  In open source XNAT its optional.  In CR its required.  So, this should be backwards compatible with open source XNAT.".

Thus it appears we do not need to check if the host is a CR instance at multiple locations (there are several functions that do not seem to have direct access to the Launcher object that would otherwise need the CR flag), we can just pass the *event_reason* parameter.

On a different note, CR appears to lock session objects and not allow changing of the timestamp even with the *event_reason* parameter which we may need to find a workaround for.
Cheers,
Baris.

@BennettLandman @mmodat 