### PR TITLE
Fix for project names that can be parsed as numbers

### DIFF
--- a/dax/bin.py
+++ b/dax/bin.py
@@ -245,7 +245,7 @@ def read_yaml_settings(yaml_file, logger):
     yaml_proc = dict()
     projects = doc.get('projects')
     for proj_dict in projects:
-        project = proj_dict.get('project')
+        project = str(proj_dict.get('project'))
         if project:
             # modules:
             if proj_dict.get('modules'):


### PR DESCRIPTION
When a setting file for a project with a name such as '1946' is read by dax, it is parsed as a number. This causes downstream logging and other code to fail in places where a string is expected and automatic type coercion doesn't happen