### PR TITLE
Matching filter

### DIFF
--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -1024,7 +1024,7 @@ in session %s'
                 LOGGER.critical(err2 % (E.__class__, E.message))
                 LOGGER.critical(traceback.format_exc())
 
-        LOGGER.debug('\n')
+        #LOGGER.debug('\n')
 
     def module_afterrun(self, xnat, project_id):
         """

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -905,6 +905,7 @@ in session %s'
             if not sess_proc.should_run(sess_info):
                 continue
 
+            # TODO: use mod time to decide if we need to reload
             csess.reload()
 
             # return a mapping between the assessor input sets and existing

--- a/dax/processor_parser.py
+++ b/dax/processor_parser.py
@@ -664,7 +664,6 @@ class ProcessorParser:
         try:
             _filters = yaml_source['inputs']['xnat']['filters']
         except KeyError as err:
-            LOGGER.error('error parsing filters:' + str(err))
             return []
 
         # Parse out filters, currently only filters of type match are supported
@@ -710,10 +709,10 @@ class ProcessorParser:
             parse(csess.scans(), artefacts)
             parse(csess.assessors(), artefacts)
 
-            LOGGER.info('inputs by assessor:')
-            for cassr in csess.assessors():
-                LOGGER.info(cassr.label())
-                LOGGER.info(str(cassr.get_inputs()))
+            #LOGGER.info('inputs by assessor:')
+            #for cassr in csess.assessors():
+            #    LOGGER.info(cassr.label())
+            #    LOGGER.info(str(cassr.get_inputs()))
         return artefacts
 
 

--- a/dax/processor_parser.py
+++ b/dax/processor_parser.py
@@ -657,24 +657,28 @@ class ProcessorParser:
         return (inputs, inputs_by_type, iteration_sources, iteration_map,
                 prior_session_count)
 
+
     @staticmethod
     def parse_match_filters(yaml_source):
         match_list = []
         try:
             _filters = yaml_source['inputs']['xnat']['filters']
         except KeyError as err:
-            print('error parsing filters:' + str(err))       
+            LOGGER.error('error parsing filters:' + str(err))
             return []
 
+        # Parse out filters, currently only filters of type match are supported
         for f in _filters:
             _type = f['type']
             if _type == 'match':
+                # Split the comma-separated list of inputs
                 _inputs = f['inputs'].split(',')
                 match_list.append(_inputs)
             else:
                 LOGGER.error('invalid filter type:{}'.format(_type))
 
         return match_list
+
 
     @staticmethod
     def parse_variables(inputs):


### PR DESCRIPTION
Adding support for an explicit matching filter that will only build an assessor if the specified artefacts match across the inputs. This allows us to ensure that an assessor will only use the set of assessors that are built on the same scan.