### PR TITLE
Implements per image session build log

### DIFF
--- a/dax/dax_manager.py
+++ b/dax/dax_manager.py
@@ -643,8 +643,10 @@ class DaxManager(object):
 
             LOGGER.info('run_build:{},{}'.format(project, lastrun))
             self.set_last_build_start(project)
+            logging.getLogger('dax').handlers = []
             dax.bin.build(
                 settings_file, log_file, debug=True, proj_lastrun=proj_lastrun)
+            logging.getLogger('dax').handlers = []
 
             # TODO: check for errors in log file and set to RED if any found,
             # also could upload last log file
@@ -662,14 +664,17 @@ class DaxManager(object):
         return self.settings_manager.get_last_run(project)
 
     def run_launch(self, settings_file, log_file):
+        logging.getLogger('dax').handlers = []
         dax.bin.launch_jobs(settings_file, log_file, debug=True)
         logging.getLogger('dax').handlers = []
 
     def run_update(self, settings_file, log_file):
+        logging.getLogger('dax').handlers = []
         dax.bin.update_tasks(settings_file, log_file, debug=True)
         logging.getLogger('dax').handlers = []
 
     def run_upload(self, log_file):
+        logging.getLogger('dax').handlers = []
         dax.dax_tools_utils.upload_tasks(log_file, True)
         logging.getLogger('dax').handlers = []
 

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -635,6 +635,8 @@ cluster queue"
             print(res_obj)
             LOGGER.debug('uploading session log:' + tmp_file)
             XnatUtils.upload_file_to_obj(tmp_file, res_obj)
+        else:
+            LOGGER.debug('session not modified, not uploading build log')
 
     def build_session_modules(self, xnat, csess, sess_mod_list):
         """

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -597,8 +597,7 @@ cluster queue"
         tmp_name = '{}_build_log-{}.txt'.format(sess_label, now_time)
         tmp_file = os.path.join(tmp_dir, tmp_name)
         print(tmp_file)
-
-        LOGGER.addHandler(tmp_file)
+        LOGGER.addHandler(logging.FileHandler(tmp_file, 'w'))
 
         if sess_mod_list or scan_mod_list:
             # Modules

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -598,6 +598,8 @@ cluster queue"
                 'build_log',
                 datetime.strftime(datetime.now(), '%Y%m%d-%H%M%S')))
 
+        print(tmp_file)
+
         LOGGER.addHandler(tmp_file)
 
         if sess_mod_list or scan_mod_list:
@@ -632,7 +634,9 @@ cluster queue"
 
         # Close sess log and upload it
         LOGGER.handlers.pop()
-        res_obj = csess.full_object().resources('BUILD_LOGS')
+        res_obj = csess.full_object().resource('BUILD_LOGS')
+        print(res_obj)
+        LOGGER.debug('uploading session log:' + tmp_file)
         XnatUtils.upload_file_to_obj(tmp_file, res_obj)
 
     def build_session_modules(self, xnat, csess, sess_mod_list):

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -586,9 +586,10 @@ cluster queue"
         :param scan_mod_list: list of modules running on a scan
         :return: None
         """
-
         csess = find_with_pred(
             sessions, lambda s: sess_info['label'] == s.session_id())
+
+        init_timestamp = csess.cached_timestamp
 
         # Create log file for this build of this session
         now_time = datetime.strftime(datetime.now(), '%Y%m%d-%H%M%S')
@@ -618,7 +619,6 @@ cluster queue"
                 if not reloaded:
                     break
 
-                # csess.reload()
                 mod_count += 1
 
         # Auto Processors
@@ -629,14 +629,9 @@ cluster queue"
         # Close sess log
         LOGGER.handlers.pop()
 
-        # TODO:
-        # Upload it only if session was changed, otherwise we'll change it here
-        # if csess.refresh(): This ain't working need to figure out why, XNAT
-        # has suddenly stopped updating the last_modifed time,
-        # so will just upload the log everytime the build runs, unfortunately 
-        # this will mean real build won't actually run b/c the last_mod 
-        # time isn't changing
-        if True:
+        # Upload build log only if session was changed
+        csess.refresh()
+        if csess.cached_timestamp > init_timestamp:
             res_obj = csess.full_object().resource('BUILD_LOGS')
             print(res_obj)
             LOGGER.debug('uploading session log:' + tmp_file)

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -629,8 +629,14 @@ cluster queue"
         # Close sess log
         LOGGER.handlers.pop()
 
+        # TODO:
         # Upload it only if session was changed, otherwise we'll change it here
-        if csess.refresh():
+        # if csess.refresh(): This ain't working need to figure out why, XNAT
+        # has suddenly stopped updating the last_modifed time,
+        # so will just upload the log everytime the build runs, unfortunately 
+        # this will mean real build won't actually run b/c the last_mod 
+        # time isn't changing
+        if True:
             res_obj = csess.full_object().resource('BUILD_LOGS')
             print(res_obj)
             LOGGER.debug('uploading session log:' + tmp_file)

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -596,8 +596,10 @@ cluster queue"
         tmp_dir = tempfile.mkdtemp()
         tmp_name = '{}_build_log-{}.txt'.format(sess_label, now_time)
         tmp_file = os.path.join(tmp_dir, tmp_name)
-        print(tmp_file)
-        LOGGER.addHandler(logging.FileHandler(tmp_file, 'w'))
+        handler = logging.FileHandler(tmp_file, 'w')
+        handler.setFormatter(logging.Formatter(
+            fmt='%(asctime)s - %(levelname)s - %(module)s - %(message)s'))
+        LOGGER.addHandler(handler)
 
         if sess_mod_list or scan_mod_list:
             # Modules

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -631,7 +631,7 @@ cluster queue"
 
         # Upload build log only if session was changed
         csess.refresh()
-        final_timestamp = csess.cached_timestamp 
+        final_timestamp = csess.cached_timestamp
         LOGGER.debug('initial timestamp={}, final timestamp={}'.format(
             init_timestamp, final_timestamp))
         if final_timestamp > init_timestamp:

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -591,12 +591,10 @@ cluster queue"
             sessions, lambda s: sess_info['label'] == s.session_id())
 
         # Create log file for this build of this session
+        now_time = datetime.strftime(datetime.now(), '%Y%m%d-%H%M%S')
         tmp_file = os.path(
             tempfile.mkdtemp(),
-            '{}_{}-{}.txt'.format(
-                csess.label(),
-                'build_log',
-                datetime.strftime(datetime.now(), '%Y%m%d-%H%M%S')))
+            '{}_build_log-{}.txt'.format(csess.label(), now_time))
 
         print(tmp_file)
 

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -631,7 +631,10 @@ cluster queue"
 
         # Upload build log only if session was changed
         csess.refresh()
-        if csess.cached_timestamp > init_timestamp:
+        final_timestamp = csess.cached_timestamp 
+        LOGGER.debug('initial timestamp={}, final timestamp={}'.format(
+            init_timestamp, final_timestamp))
+        if final_timestamp > init_timestamp:
             res_obj = csess.full_object().resource('BUILD_LOGS')
             print(res_obj)
             LOGGER.debug('uploading session log:' + tmp_file)

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -592,10 +592,10 @@ cluster queue"
 
         # Create log file for this build of this session
         now_time = datetime.strftime(datetime.now(), '%Y%m%d-%H%M%S')
-        tmp_file = os.path(
-            tempfile.mkdtemp(),
-            '{}_build_log-{}.txt'.format(csess.label(), now_time))
-
+        sess_label = csess.label()
+        tmp_dir = tempfile.mkdtemp()
+        tmp_name = '{}_build_log-{}.txt'.format(sess_label, now_time)
+        tmp_file = os.path(tmp_dir, tmp_name)
         print(tmp_file)
 
         LOGGER.addHandler(tmp_file)

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -595,7 +595,7 @@ cluster queue"
         sess_label = csess.label()
         tmp_dir = tempfile.mkdtemp()
         tmp_name = '{}_build_log-{}.txt'.format(sess_label, now_time)
-        tmp_file = os.path(tmp_dir, tmp_name)
+        tmp_file = os.path.join(tmp_dir, tmp_name)
         print(tmp_file)
 
         LOGGER.addHandler(tmp_file)

--- a/dax/log.py
+++ b/dax/log.py
@@ -24,7 +24,7 @@ def setup_debug_logger(name, logfile):
     handler.setFormatter(formatter)
 
     # logger = logging.getLogger(name)
-    logger = multiprocessing.get_logger(name)
+    logger = multiprocessing.get_logger()
     logger.setLevel(logging.DEBUG)
     logger.addHandler(handler)
     return logger
@@ -45,7 +45,7 @@ def setup_info_logger(name, logfile):
         handler = logging.StreamHandler(sys.stdout)
 
     # logger = logging.get_logger(name)
-    logger = multiprocessing.get_logger(name)
+    logger = multiprocessing.get_logger()
     logger.setLevel(logging.INFO)
     logger.addHandler(handler)
     return logger

--- a/dax/log.py
+++ b/dax/log.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import multiprocessing
 import logging
 import sys
 
@@ -23,8 +22,7 @@ def setup_debug_logger(name, logfile):
         handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(formatter)
 
-    # logger = logging.getLogger(name)
-    logger = multiprocessing.get_logger()
+    logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)
     logger.addHandler(handler)
     return logger
@@ -44,8 +42,7 @@ def setup_info_logger(name, logfile):
     else:
         handler = logging.StreamHandler(sys.stdout)
 
-    # logger = logging.get_logger(name)
-    logger = multiprocessing.get_logger()
+    logger = logging.getLogger(name)
     logger.setLevel(logging.INFO)
     logger.addHandler(handler)
     return logger

--- a/dax/log.py
+++ b/dax/log.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+import multiprocessing
 import logging
 import sys
 
@@ -23,7 +23,8 @@ def setup_debug_logger(name, logfile):
         handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(formatter)
 
-    logger = logging.getLogger(name)
+    # logger = logging.getLogger(name)
+    logger = multiprocessing.get_logger(name)
     logger.setLevel(logging.DEBUG)
     logger.addHandler(handler)
     return logger
@@ -43,7 +44,8 @@ def setup_info_logger(name, logfile):
     else:
         handler = logging.StreamHandler(sys.stdout)
 
-    logger = logging.getLogger(name)
+    # logger = logging.get_logger(name)
+    logger = multiprocessing.get_logger(name)
     logger.setLevel(logging.INFO)
     logger.addHandler(handler)
     return logger


### PR DESCRIPTION
When an image session is modified during dax build, the portion of the build logging for the session is uploaded to XNAT. The file will appear under the session resource named BUILD_LOG. The file is named with a timestamp.