### PR TITLE
BIDS/XNAT Support

### DIFF
--- a/bin/Xnat_tools/BIDSMapping
+++ b/bin/Xnat_tools/BIDSMapping
@@ -16,12 +16,40 @@ import argparse
 from dax import XnatUtils
 from datetime import datetime
 
+DESCRIPTION = """What is the script doing :
+   *Uploads BIDS datatype, tasktype and repitition time mapping to XNAT project level using the \
+different OPTIONS.
+
+Examples:
+   *Create a new datatype mapping for scan_type of XNAT scans:
+        BIDSMapping -p PID --xnatinfo scan_type --type datatype --create /tmp/projectID_datataype.csv
+   *The correct format for /tmp/projectID_datataype.csv
+        scan_type,datatype
+        Resting State,func
+   *Create a new datatype mapping for series_description of XNAT scans:
+        BIDSMapping -p PID --xnatinfo series_description --type datatype --create /tmp/projectID_datataype.csv
+   *Create a new tasktype mapping for scan_type of XNAT scans:
+        BIDSMapping -p PID --xnatinfo scan_type --type tasktype --create /tmp/projectID_tasktype.csv 
+   *Replace tasktype mapping for scan_type of XNAT scans: (It removes the old mapping and upload the new mapping)
+        BIDSMapping -p PID --xnatinfo scan_type --type tasktype --replace /tmp/projectID_tasktype.csv
+   *Update tasktype mapping for scan_type of XNAT scans: (This is ONLY add new mapping rules, CANT remove rules \
+     use --replace to remove and add mapping rules)
+        BIDSMapping -p PID --xnatinfo scan_type --type tasktype --update /tmp/projectID_tasktype.csv
+   *Create default datatype mapping for scan_type of XNAT scans: (There is no default for series_description \
+     use --create)
+        BIDSMapping -p PID --xnatinfo scan_type --type datatype --create_default 
+   *Download the current mapping on XNAT:
+        BIDSMapping -p PID --xnatinfo scan_type --type datatype --download /tmp/download.csv 
+    *Download the scan_types on project on XNAT:
+        BIDSMapping -p PID --template /tmp/scan_type_template.csv 
+"""
+
 def add_parser_args():
     """
     Method to parse all the arguments for the tool on ArgumentParser
     :return: parser object
     """
-    argp = argparse.ArgumentParser(description='details', usage='use "%(prog)s --help" for more information',
+    argp = argparse.ArgumentParser(description=DESCRIPTION, usage='use "%(prog)s --help" for more information',
                                    formatter_class=argparse.RawTextHelpFormatter)
     # Connect to XNAT
     argp.add_argument('--host', dest='host', default=None,
@@ -31,16 +59,16 @@ def add_parser_args():
     argp.add_argument("-o", "--logfile", dest="logfile", default=None,
                       help="Write the display/output in a file given to this OPTIONS.")
     # Specify Project [Required]
-    argp.add_argument('--project', dest="project", default=None,
+    argp.add_argument("-p",'--project', dest="project", default=None,
                       help='Project to create/update BIDS mapping file')
     # Specify Type of BIDS Mapping [Required]
-    argp.add_argument('--type', dest="type", default=None,
+    argp.add_argument('-t','--type', dest="type", default=None,
                       help='The type of mapping either datatype, tasktype or repetition_time_sec')
     # Specify XNAT type for mapping [Required]
-    argp.add_argument('--xnatinfo', dest="xnatinfo", default=None,
+    argp.add_argument('-x','--xnatinfo', dest="xnatinfo", default=None,
                       help='The type of xnat info to use for mapping either scan_type or series_description')
     # Create mapping rules at Project level
-    argp.add_argument('--create', dest="create", action=None,
+    argp.add_argument('-c','--create', dest="create", action=None,
                       help='Create the given BIDS new mapping file at project level. (EG. --create <mappingfile>.csv)\n'
                            'Default create creates the default mapping at project file. (EG. --create)\n'
                            'csvfile EG:\n'
@@ -48,25 +76,25 @@ def add_parser_args():
                            'T1W/3D/TFE,anat\n'
                            'Resting State,func\n')
     # Create default mapping rules at Project level (default mapping is regex on LANDMAN project)
-    argp.add_argument('--create_default', dest="create_default", action='store_true',
+    argp.add_argument('-cd','--create_default', dest="create_default", action='store_true',
                       help='Default create creates the default mapping at project file. (EG. --create_default)')
     # Update mapping rules (it can only add new rules) at Project level
-    argp.add_argument('--update', dest="update", default=None,
-                      help='Update the existing BIDS mapping file at project level. (EG. --update <mappingfile>.csv)'
+    argp.add_argument('-u','--update', dest="update", default=None,
+                      help='Update the existing BIDS mapping file at project level. (EG. --update <mappingfile>.csv)\n'
                            'This option can only add rules')
     # Replace mapping rules (it will remove previous rules and add new rules) at Project level
-    argp.add_argument('--replace', dest="replace",  default=None,
-                      help='Replace the existing BIDS mapping file at project level. (EG. --replace <mappingfile>.csv)'
+    argp.add_argument('-rp','--replace', dest="replace",  default=None,
+                      help='Replace the existing BIDS mapping file at project level. (EG. --replace <mappingfile>.csv)\n'
                            'This option can remove and add new rules')
     # Change the mapping rules to a specific time from the LOGFILE at the Project level
-    argp.add_argument('--revert', dest="revert", default=None,
-                      help='Revert to an old mapping from a specific date/time. (EG: --revert 10-17-19-21:32:15'
+    argp.add_argument('-rv','--revert', dest="revert", default=None,
+                      help='Revert to an old mapping from a specific date/time. (EG: --revert 10-17-19-21:32:15\n'
                            'or --revert 10-17-19). Check the LOGFILE at project level for the date')
     # Download current mapping rules at the Project level
-    argp.add_argument('--download', dest="download",  action=None,
+    argp.add_argument('-d','--download', dest="download",  action=None,
                       help='Downloads the current BIDS mapping file (EG: --download <foldername>)')
     # Get a list of scan_type of the Project
-    argp.add_argument('--template', dest="template", action=None,
+    argp.add_argument('-t','--template', dest="template", action=None,
                       help='Default mapping template (EG: --template <template file>)')
 
     return argp

--- a/bin/Xnat_tools/BIDSMapping
+++ b/bin/Xnat_tools/BIDSMapping
@@ -79,7 +79,7 @@ def add_parser_args():
     argp.add_argument('-cd','--create_default', dest="create_default", action='store_true',
                       help='Default create creates the default mapping at project file. (EG. --create_default)')
     # Update mapping rules (it can only add new rules) at Project level
-    argp.add_argument('-u','--update', dest="update", default=None,
+    argp.add_argument('-ud','--update', dest="update", default=None,
                       help='Update the existing BIDS mapping file at project level. (EG. --update <mappingfile>.csv)\n'
                            'This option can only add rules')
     # Replace mapping rules (it will remove previous rules and add new rules) at Project level
@@ -94,7 +94,7 @@ def add_parser_args():
     argp.add_argument('-d','--download', dest="download",  action=None,
                       help='Downloads the current BIDS mapping file (EG: --download <foldername>)')
     # Get a list of scan_type of the Project
-    argp.add_argument('-t','--template', dest="template", action=None,
+    argp.add_argument('-tp','--template', dest="template", action=None,
                       help='Default mapping template (EG: --template <template file>)')
 
     return argp

--- a/bin/Xnat_tools/BIDSMapping
+++ b/bin/Xnat_tools/BIDSMapping
@@ -76,25 +76,25 @@ def add_parser_args():
                            'T1W/3D/TFE,anat\n'
                            'Resting State,func\n')
     # Create default mapping rules at Project level (default mapping is regex on LANDMAN project)
-    argp.add_argument('-cd','--create_default', dest="create_default", action='store_true',
+    argp.add_argument('--cd','--create_default', dest="create_default", action='store_true',
                       help='Default create creates the default mapping at project file. (EG. --create_default)')
     # Update mapping rules (it can only add new rules) at Project level
-    argp.add_argument('-ud','--update', dest="update", default=None,
+    argp.add_argument('-a','--update', dest="update", default=None,
                       help='Update the existing BIDS mapping file at project level. (EG. --update <mappingfile>.csv)\n'
                            'This option can only add rules')
     # Replace mapping rules (it will remove previous rules and add new rules) at Project level
-    argp.add_argument('-rp','--replace', dest="replace",  default=None,
+    argp.add_argument('-r','--replace', dest="replace",  default=None,
                       help='Replace the existing BIDS mapping file at project level. (EG. --replace <mappingfile>.csv)\n'
                            'This option can remove and add new rules')
     # Change the mapping rules to a specific time from the LOGFILE at the Project level
-    argp.add_argument('-rv','--revert', dest="revert", default=None,
+    argp.add_argument('-v','--revert', dest="revert", default=None,
                       help='Revert to an old mapping from a specific date/time. (EG: --revert 10-17-19-21:32:15\n'
                            'or --revert 10-17-19). Check the LOGFILE at project level for the date')
     # Download current mapping rules at the Project level
     argp.add_argument('-d','--download', dest="download",  action=None,
                       help='Downloads the current BIDS mapping file (EG: --download <foldername>)')
     # Get a list of scan_type of the Project
-    argp.add_argument('-tp','--template', dest="template", action=None,
+    argp.add_argument('--template', dest="template", action=None,
                       help='Default mapping template (EG: --template <template file>)')
 
     return argp

--- a/bin/Xnat_tools/BIDSMapping
+++ b/bin/Xnat_tools/BIDSMapping
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 '''
 Create/Upload BIDS datatype/tasktype mapping.
 
@@ -17,26 +16,31 @@ import argparse
 from dax import XnatUtils
 from datetime import datetime
 
-UNSPECIFIED = object()
+
 def add_parser_args():
     """
-    The arguments for the tool
-    :return:
+    Method to parse all the arguments for the tool on ArgumentParser
+    :return: parser object
     """
     argp = argparse.ArgumentParser(description='details', usage='use "%(prog)s --help" for more information',
                                    formatter_class=argparse.RawTextHelpFormatter)
+    # Connect to XNAT
     argp.add_argument('--host', dest='host', default=None,
                       help='Host for XNAT. Default: using $XNAT_HOST.')
     argp.add_argument('-u', '--username', dest='username', default=None,
                       help='Username for XNAT. Default: using $XNAT_USER.')
     argp.add_argument("-o", "--logfile", dest="logfile", default=None,
                       help="Write the display/output in a file given to this OPTIONS.")
+    # Specify Project [Required]
     argp.add_argument('--project', dest="project", default=None,
                       help='Project to create/update BIDS mapping file')
+    # Specify Type of BIDS Mapping [Required]
     argp.add_argument('--type', dest="type", default=None,
                       help='The type of mapping either datatype, tasktype or repetition_time_sec')
+    # Specify XNAT type for mapping [Required]
     argp.add_argument('--xnatinfo', dest="xnatinfo", default=None,
                       help='The type of xnat info to use for mapping either scan_type or series_description')
+    # Create mapping rules at Project level
     argp.add_argument('--create', dest="create", action=None,
                       help='Create the given BIDS new mapping file at project level. (EG. --create <mappingfile>.csv)\n'
                            'Default create creates the default mapping at project file. (EG. --create)\n'
@@ -44,21 +48,27 @@ def add_parser_args():
                            'scan_type,datatype\n'
                            'T1W/3D/TFE,anat\n'
                            'Resting State,func\n')
+    # Create default mapping rules at Project level (default mapping is regex on LANDMAN project)
     argp.add_argument('--create_default', dest="create_default", action='store_true',
                       help='Default create creates the default mapping at project file. (EG. --create_default)')
+    # Update mapping rules (it can only add new rules) at Project level
     argp.add_argument('--update', dest="update", default=None,
                       help='Update the existing BIDS mapping file at project level. (EG. --update <mappingfile>.csv)'
                            'This option can only add rules')
+    # Replace mapping rules (it will remove previous rules and add new rules) at Project level
     argp.add_argument('--replace', dest="replace",  default=None,
                       help='Replace the existing BIDS mapping file at project level. (EG. --replace <mappingfile>.csv)'
                            'This option can remove and add new rules')
+    # Change the mapping rules to a specific time from the LOGFILE at the Project level
     argp.add_argument('--revert', dest="revert", default=None,
                       help='Revert to an old mapping from a specific date/time. (EG: --revert 10-17-19-21:32:15'
                            'or --revert 10-17-19). Check the LOGFILE at project level for the date')
+    # Download current mapping rules at the Project level
     argp.add_argument('--download', dest="download",  action=None,
                       help='Downloads the current BIDS mapping file (EG: --download <foldername>)')
-    argp.add_argument('--template', dest="template",  default=None,
-                      help='Default mapping template')
+    # Get a list of scan_type of the Project
+    argp.add_argument('--template', dest="template", action=None,
+                      help='Default mapping template (EG: --template <template file>)')
 
     return argp
 
@@ -83,18 +93,18 @@ def setup_info_logger(name, logfile):
 
 def template():
     """
-    Function to generate the scan type from a project
-    in csv
-    :return:
+    Method to generate all the scan type from a project in csv
     """
     #TODO sd | default mapping | rule at project level
     sd_list = []
     template_dir = OPTIONS.template
+    # Get all the unique scans in the project
     scans_list_global = XNAT.get_project_scans(project)
     for sd in scans_list_global:
         sd_list.append(sd['scan_type'])
     sd_set = set(sd_list)
     uniq_sd = [_f for _f in list(sd_set) if _f]
+    # Write the list to directory given by the user
     with open(template_dir, "w+") as f:
         wr = csv.writer(f)
         for row in uniq_sd:
@@ -103,16 +113,17 @@ def template():
 
 def default():
     """
-    Function to make the default mapping at project level if
-    mapping does not exit
-    #TODO go back to default when wanted? use findchange for logging??
-    :return:
+    Function to create the default mapping at project level if
+    previous mapping does not exit
+    #TODO go back to default when wanted. Use findchange for logging
     """
     new_mapping = dict()
     new_mapping[project] = {}
+    # Since Repetition time should be given by user, it has no default mapping
     if mapping_type == 'repetition_time_sec':
         LOGGER.info('Repetition time does not have default mapping, use --create')
     else:
+        # Get the scan type from LANDMAN and use regex to create mapping for those scans and BIDS datatype
         if mapping_type == 'datatype':
             scans_list_global = XNAT.get_project_scans('LANDMAN')
 
@@ -135,7 +146,7 @@ def default():
                     new_mapping[project][sd_dwi] = "dwi"
 
             for sd in scans_list_global:
-                c = re.search('Field|B0', sd['scan_type'], flags=re.IGNORECASE)
+                c = re.search('Field', sd['scan_type'], flags=re.IGNORECASE)
                 if not c == None:
                     sd_fmap = sd['scan_type']
                     new_mapping[project][sd_fmap] = "fmap"
@@ -149,13 +160,8 @@ def default():
                     new_mapping[project][sd_func] = "rest"
 
         new_json_name = d_m_y + '_' + mapping_type + '.json'
-        is_json_present = False
-        for res in XNAT.select(res_files).get():
-            if not res.endswith('.json'):
-                continue
-            else:
-                is_json_present = True
-
+        # If mapping is not present upload the mapping created (above) with regex, if not throw an error
+        is_json_present = check_mapping_exist()
         if not is_json_present:
             XNAT.select(os.path.join(res_files, new_json_name)).put(src=json.dumps(new_mapping, indent=2))
             log_new_mapping(new_mapping)
@@ -164,13 +170,24 @@ def default():
             LOGGER.info('Datatype mapping exists at project level. You can update it using --update to update it '
                         'or --replace to replace the mapping')
 
+def check_mapping_exist():
+    """
+    Method to check if json mapping exists at Project level
+    """
+    is_json_present = False
+    for res in XNAT.select(res_files).get():
+        if not res.endswith('.json'):
+            continue
+        else:
+            is_json_present = True
+    return is_json_present
 
 def create():
     """
     Function to read the given csv file and create new mapping
     at project level
-    :return:
     """
+    # Read the given csv data into new_mapping
     dir_new_csv = OPTIONS.create
     new_mapping = dict()
     new_mapping[project] = {}
@@ -186,14 +203,10 @@ def create():
             elif mapping_type == 'repetition_time_sec':
                 new_mapping[project][sd] = rows['repetition_time_sec']
     LOGGER.info('date %s' % (date.strftime("%d-%m-%y-%H:%M:%S")))
-    new_json_name = d_m_y + '_' + mapping_type + '.json'
-    is_json_present = False
-    for res in XNAT.select(res_files).get():
-        if not res.endswith('.json'):
-            continue
-        else:
-            is_json_present = True
 
+    # If  mapping is not present upload the new_mapping from the CSV, if not throw an error
+    new_json_name = d_m_y + '_' + mapping_type + '.json'
+    is_json_present = check_mapping_exist()
     if not is_json_present:
         XNAT.select(os.path.join(res_files, new_json_name)).put(src=json.dumps(new_mapping, indent=2))
         log_new_mapping(new_mapping)
@@ -205,22 +218,22 @@ def create():
 
 def log_new_mapping(d):
     """
-    Logging when new mapping is created fat project level
+    Method to log the rules (mapping) when new mapping is created at project level
     :param d: new mapping
-    :return:
     """
-    for k, v in d[project].items():
+    for k, v in list(d[project].items()):
         row0 = d_m_y, " + ", k + " : " + v
         CSVWRITER.writerow(row0)
 
 
-def update():
+def update_or_replace():
     """
-    Function to read the csv file with new rules and to add new rules
-    at project level
-    :return:
+    Function to read the csv file with new rules and add these new rules
+    at project level. Update can only add new rules. Replace will remove the
+    previous rules and add new ones
     """
     new_json_name = d_m_y + '_' + mapping_type + '.json'
+    # Get the CSV path for CSV mapping file
     if OPTIONS.update:
         src_path = OPTIONS.update
     if OPTIONS.replace:
@@ -238,6 +251,7 @@ def update():
                 new_mapping[project][sd] = rows['tasktype']
             elif mapping_type == 'repetition_time_sec':
                 new_mapping[project][sd] = rows['repetition_time_sec']
+    # Get the json mapping from XNAT
     if len(XNAT.select(res_files).get()) > 1:
         for res in XNAT.select(res_files).get():
             if res.endswith('.json'):
@@ -251,7 +265,7 @@ def update():
                             if OPTIONS.replace:
                                 findDiff_change(new_mapping, prev_mapping)
                                 prev_mapping = new_mapping
-
+                        # Dump the updated previous mapping
                         XNAT.select(os.path.join(res_files, new_json_name)).put(src=
                                                                                 json.dumps(prev_mapping, indent=2),
                                                                                 overwrite=True)
@@ -264,10 +278,13 @@ def update():
         LOGGER.error('ERROR: No mapping at project level to update or replace')
 
 def csv_check(src_path):
+    """
+    Method to check if the csv file used by the user has the correct values in columns
+    """
     with open(src_path, 'r') as csvFile:
         csvReader = csv.DictReader(csvFile)
         if csvReader.fieldnames[0] in ["scan_type","series_description"] and csvReader.fieldnames[1] in \
-                ["datatype", "tasktype", "repetition_time_sec"]:
+                ["datatype", "tasktype", "repetition_time_sec"] and csvReader.fieldnames[0] == xnat_type and csvReader.fieldnames[1] == mapping_type:
             if csvReader.fieldnames[1] == "datatype":
                 for rows in csvReader:
                     if rows['datatype'] not in ["anat", "dwi", "func", "fmap"]:
@@ -277,14 +294,14 @@ def csv_check(src_path):
             else:
                 LOGGER.info("CSV mapping format is good")
         else:
-            LOGGER.error("ERROR in CSV column headers. Column headers should be datatype, tasktype or repetition_time_sec")
+            LOGGER.error("ERROR in CSV column headers. Check 1) if the xnat_info and column header match, 2) if the type and column header match, "
+                         "3) column headers should be series_description or scan_type and datatype, tasktype or repetition_time_sec")
             sys.exit()
 
 def revert():
     """
     Function to go back a mapping of a previous date/time
     using the log file at project level
-    :return:
     """
     new_json_name = d_m_y + '_' + mapping_type + '.json'
     orig_mapping = None
@@ -321,9 +338,8 @@ def findDiff(d1, d2, path=""):
     :param d1: dict with new mapping
     :param d2: dict with old mapping
     :param path: ""
-    :return:
     """
-    for k, v in d1.items():
+    for k, v in list(d1.items()):
         if k not in list(d2.keys()):
             row1 = d_m_y, " + ", k + " : " + v
             CSVWRITER.writerow(row1)
@@ -342,30 +358,26 @@ def findDiff(d1, d2, path=""):
                     CSVWRITER.writerow(row3)
 
 
-def findDiff_change(d1, d2, path=""):
+def findDiff_change(d1, d2):
     """
     Function to record/log the changing made when reverting rules
     :param d1: dict with new mapping
     :param d2: dict with previous mapping
     :param path: ""
-    :return:
     """
-    for d1_k, d1_v in d1.items():
-        for k, v in d1[d1_k].items():
+    for d1_k, d1_v in list(d1.items()):
+        for k, v in list(d1[d1_k].items()):
             row4 = d_m_y, " + ", k + " : " + v
             CSVWRITER.writerow(row4)
-    for d2_k, d2_v in d1.items():
-        for k, v in d2[d2_k].items():
+    for d2_k, d2_v in list(d1.items()):
+        for k, v in list(d2[d2_k].items()):
             row5 = d_m_y, " - ", k + " : " + v
             CSVWRITER.writerow(row5)
-
-
 
 
 def mapping_download():
     """
     Function to download the mapping file at project level
-    :return:
     """
     download_file = OPTIONS.download
     download_dir = os.path.join(os.getcwd(), download_file)
@@ -403,6 +415,7 @@ if __name__ == '__main__':
         if OPTIONS.template:
             template()
         else:
+            # Put the XNAT type info at project level in xnat_type.txt
             xnat_type_file = XNAT.select('/data/projects/' + project + '/resources/BIDS_xnat_type/files/xnat_type.txt')
             if not OPTIONS.xnatinfo:
                 LOGGER.info("WARNING: Xnatinfo is required. Use --xnatinfo")
@@ -423,19 +436,20 @@ if __name__ == '__main__':
                     res_files = '/data/projects/' + project + '/resources/BIDS_' + mapping_type + '/files'
                     xnat_logfile = XNAT.select(os.path.join(res_files, 'LOGFILE.txt'))
                     if not xnat_logfile.exists():
+                        # If LOGFILE does not exist revert cant be done
                         if OPTIONS.revert:
                             LOGGER.error('Cannot perform --revert. Create mapping with --create option first')
                             sys.exit()
                         xnat_logfile.put(src="Logfile\n")
                     LOGFILE = xnat_logfile.get()
-                    csvfilewrite = open(LOGFILE, 'ab')
+                    csvfilewrite = open(LOGFILE, 'a')
                     CSVWRITER = csv.writer(csvfilewrite, delimiter=',')
                     if OPTIONS.create:
                         create()
                     if OPTIONS.create_default:
                         default()
                     if OPTIONS.update or OPTIONS.replace:
-                        update()
+                        update_or_replace()
                     if OPTIONS.revert:
                         revert()
                     if OPTIONS.download:
@@ -443,3 +457,4 @@ if __name__ == '__main__':
 
                     csvfilewrite.close()
                     XNAT.select(os.path.join(res_files, 'LOGFILE.txt')).put(src=LOGFILE, overwrite=True)
+

--- a/bin/Xnat_tools/BIDSMapping
+++ b/bin/Xnat_tools/BIDSMapping
@@ -1,0 +1,445 @@
+#!/usr/bin/env python
+
+'''
+Create/Upload BIDS datatype/tasktype mapping.
+
+Created on October, 2019
+
+@author: Praitayini Kanakaraj, Electrical Engineering, Vanderbilt University
+'''
+import os
+import re
+import csv
+import sys
+import json
+import logging
+import argparse
+from dax import XnatUtils
+from datetime import datetime
+
+UNSPECIFIED = object()
+def add_parser_args():
+    """
+    The arguments for the tool
+    :return:
+    """
+    argp = argparse.ArgumentParser(description='details', usage='use "%(prog)s --help" for more information',
+                                   formatter_class=argparse.RawTextHelpFormatter)
+    argp.add_argument('--host', dest='host', default=None,
+                      help='Host for XNAT. Default: using $XNAT_HOST.')
+    argp.add_argument('-u', '--username', dest='username', default=None,
+                      help='Username for XNAT. Default: using $XNAT_USER.')
+    argp.add_argument("-o", "--logfile", dest="logfile", default=None,
+                      help="Write the display/output in a file given to this OPTIONS.")
+    argp.add_argument('--project', dest="project", default=None,
+                      help='Project to create/update BIDS mapping file')
+    argp.add_argument('--type', dest="type", default=None,
+                      help='The type of mapping either datatype, tasktype or repetition_time_sec')
+    argp.add_argument('--xnatinfo', dest="xnatinfo", default=None,
+                      help='The type of xnat info to use for mapping either scan_type or series_description')
+    argp.add_argument('--create', dest="create", action=None,
+                      help='Create the given BIDS new mapping file at project level. (EG. --create <mappingfile>.csv)\n'
+                           'Default create creates the default mapping at project file. (EG. --create)\n'
+                           'csvfile EG:\n'
+                           'scan_type,datatype\n'
+                           'T1W/3D/TFE,anat\n'
+                           'Resting State,func\n')
+    argp.add_argument('--create_default', dest="create_default", action='store_true',
+                      help='Default create creates the default mapping at project file. (EG. --create_default)')
+    argp.add_argument('--update', dest="update", default=None,
+                      help='Update the existing BIDS mapping file at project level. (EG. --update <mappingfile>.csv)'
+                           'This option can only add rules')
+    argp.add_argument('--replace', dest="replace",  default=None,
+                      help='Replace the existing BIDS mapping file at project level. (EG. --replace <mappingfile>.csv)'
+                           'This option can remove and add new rules')
+    argp.add_argument('--revert', dest="revert", default=None,
+                      help='Revert to an old mapping from a specific date/time. (EG: --revert 10-17-19-21:32:15'
+                           'or --revert 10-17-19). Check the LOGFILE at project level for the date')
+    argp.add_argument('--download', dest="download",  action=None,
+                      help='Downloads the current BIDS mapping file (EG: --download <foldername>)')
+    argp.add_argument('--template', dest="template",  default=None,
+                      help='Default mapping template')
+
+    return argp
+
+def setup_info_logger(name, logfile):
+    """
+    Using logger for the executables output.
+     Setting the information for the logger.
+
+    :param name: Name of the logger
+    :param logfile: log file path to write outputs
+    :return: logging object
+    """
+    if logfile:
+        handler = logging.FileHandler(logfile, 'w')
+    else:
+        handler = logging.StreamHandler()
+
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+    return logger
+
+def template():
+    """
+    Function to generate the scan type from a project
+    in csv
+    :return:
+    """
+    #TODO sd | default mapping | rule at project level
+    sd_list = []
+    template_dir = OPTIONS.template
+    scans_list_global = XNAT.get_project_scans(project)
+    for sd in scans_list_global:
+        sd_list.append(sd['scan_type'])
+    sd_set = set(sd_list)
+    uniq_sd = [_f for _f in list(sd_set) if _f]
+    with open(template_dir, "w+") as f:
+        wr = csv.writer(f)
+        for row in uniq_sd:
+            wr.writerow([row])
+    LOGGER.info('Template with scan_type at %s', template_dir)
+
+def default():
+    """
+    Function to make the default mapping at project level if
+    mapping does not exit
+    #TODO go back to default when wanted? use findchange for logging??
+    :return:
+    """
+    new_mapping = dict()
+    new_mapping[project] = {}
+    if mapping_type == 'repetition_time_sec':
+        LOGGER.info('Repetition time does not have default mapping, use --create')
+    else:
+        if mapping_type == 'datatype':
+            scans_list_global = XNAT.get_project_scans('LANDMAN')
+
+            for sd in scans_list_global:
+                c = re.search('T1|T2|T1W', sd['scan_type'])
+                if not c == None:
+                    sd_anat = sd['scan_type']
+                    new_mapping[project][sd_anat] = "anat"
+
+            for sd in scans_list_global:
+                c = re.search('rest|Resting state', sd['scan_type'], flags=re.IGNORECASE)
+                if not c == None:
+                    sd_func = sd['scan_type']
+                    new_mapping[project][sd_func] = "func"
+
+            for sd in scans_list_global:
+                c = re.search('dwi|dti', sd['scan_type'], flags=re.IGNORECASE)
+                if not c == None:
+                    sd_dwi = sd['scan_type']
+                    new_mapping[project][sd_dwi] = "dwi"
+
+            for sd in scans_list_global:
+                c = re.search('Field|B0', sd['scan_type'], flags=re.IGNORECASE)
+                if not c == None:
+                    sd_fmap = sd['scan_type']
+                    new_mapping[project][sd_fmap] = "fmap"
+
+        if mapping_type == 'tasktype':
+            scans_list_global = XNAT.get_project_scans('LANDMAN')
+            for sd in scans_list_global:
+                c = re.search('rest', sd['scan_type'], flags=re.IGNORECASE)
+                if not c == None:
+                    sd_func = sd['scan_type']
+                    new_mapping[project][sd_func] = "rest"
+
+        new_json_name = d_m_y + '_' + mapping_type + '.json'
+        is_json_present = False
+        for res in XNAT.select(res_files).get():
+            if not res.endswith('.json'):
+                continue
+            else:
+                is_json_present = True
+
+        if not is_json_present:
+            XNAT.select(os.path.join(res_files, new_json_name)).put(src=json.dumps(new_mapping, indent=2))
+            log_new_mapping(new_mapping)
+            LOGGER.info('CREATED: Default mapping file %s is uploaded' % new_json_name)
+        else:
+            LOGGER.info('Datatype mapping exists at project level. You can update it using --update to update it '
+                        'or --replace to replace the mapping')
+
+
+def create():
+    """
+    Function to read the given csv file and create new mapping
+    at project level
+    :return:
+    """
+    dir_new_csv = OPTIONS.create
+    new_mapping = dict()
+    new_mapping[project] = {}
+    csv_check(dir_new_csv)
+    with open(dir_new_csv) as csvFile:
+        csvReader = csv.DictReader(csvFile)
+        for rows in csvReader:
+            sd = rows[xnat_type]
+            if mapping_type == 'datatype':
+                new_mapping[project][sd] = rows['datatype']
+            elif mapping_type == 'tasktype':
+                new_mapping[project][sd] = rows['tasktype']
+            elif mapping_type == 'repetition_time_sec':
+                new_mapping[project][sd] = rows['repetition_time_sec']
+    LOGGER.info('date %s' % (date.strftime("%d-%m-%y-%H:%M:%S")))
+    new_json_name = d_m_y + '_' + mapping_type + '.json'
+    is_json_present = False
+    for res in XNAT.select(res_files).get():
+        if not res.endswith('.json'):
+            continue
+        else:
+            is_json_present = True
+
+    if not is_json_present:
+        XNAT.select(os.path.join(res_files, new_json_name)).put(src=json.dumps(new_mapping, indent=2))
+        log_new_mapping(new_mapping)
+        LOGGER.info('CREATED: New mapping file %s is uploaded' % new_json_name)
+    else:
+        LOGGER.info('Mapping exists at project level. You can update it using --update to update it '
+                    'or --replace to replace the mapping')
+
+
+def log_new_mapping(d):
+    """
+    Logging when new mapping is created fat project level
+    :param d: new mapping
+    :return:
+    """
+    for k, v in d[project].items():
+        row0 = d_m_y, " + ", k + " : " + v
+        CSVWRITER.writerow(row0)
+
+
+def update():
+    """
+    Function to read the csv file with new rules and to add new rules
+    at project level
+    :return:
+    """
+    new_json_name = d_m_y + '_' + mapping_type + '.json'
+    if OPTIONS.update:
+        src_path = OPTIONS.update
+    if OPTIONS.replace:
+        src_path = OPTIONS.replace
+    new_mapping = dict()
+    new_mapping[project] = {}
+    csv_check(src_path)
+    with open(src_path, 'r') as csvFile:
+        csvReader = csv.DictReader(csvFile)
+        for rows in csvReader:
+            sd = rows[xnat_type]
+            if mapping_type == 'datatype':
+                new_mapping[project][sd] = rows['datatype']
+            elif mapping_type == 'tasktype':
+                new_mapping[project][sd] = rows['tasktype']
+            elif mapping_type == 'repetition_time_sec':
+                new_mapping[project][sd] = rows['repetition_time_sec']
+    if len(XNAT.select(res_files).get()) > 1:
+        for res in XNAT.select(res_files).get():
+            if res.endswith('.json'):
+                with open(XNAT.select(os.path.join(res_files, res)).get(dest=os.path.join("/tmp",res)), "r+") as f:
+                    prev_mapping = json.load(f)
+                    if project in list(prev_mapping.keys()):
+                        for k, v in list(new_mapping.items()):
+                            if OPTIONS.update:
+                                findDiff(new_mapping, prev_mapping)
+                                prev_mapping[k].update(v)
+                            if OPTIONS.replace:
+                                findDiff_change(new_mapping, prev_mapping)
+                                prev_mapping = new_mapping
+
+                        XNAT.select(os.path.join(res_files, new_json_name)).put(src=
+                                                                                json.dumps(prev_mapping, indent=2),
+                                                                                overwrite=True)
+                        XNAT.select(os.path.join(res_files, res)).delete()
+                        os.remove(os.path.join("/tmp",res))
+                        LOGGER.info('UPDATED: uploaded mapping file %s' % new_json_name)
+                    else:
+                        LOGGER.error('ERROR: The mapping file format should have project as key')
+    else:
+        LOGGER.error('ERROR: No mapping at project level to update or replace')
+
+def csv_check(src_path):
+    with open(src_path, 'r') as csvFile:
+        csvReader = csv.DictReader(csvFile)
+        if csvReader.fieldnames[0] in ["scan_type","series_description"] and csvReader.fieldnames[1] in \
+                ["datatype", "tasktype", "repetition_time_sec"]:
+            if csvReader.fieldnames[1] == "datatype":
+                for rows in csvReader:
+                    if rows['datatype'] not in ["anat", "dwi", "func", "fmap"]:
+                        LOGGER.error("ERROR in CSV unknown datatype column. Datatype should be anat, dwi, fmap or func")
+                        sys.exit()
+                LOGGER.info("CSV mapping format is good")
+            else:
+                LOGGER.info("CSV mapping format is good")
+        else:
+            LOGGER.error("ERROR in CSV column headers. Column headers should be datatype, tasktype or repetition_time_sec")
+            sys.exit()
+
+def revert():
+    """
+    Function to go back a mapping of a previous date/time
+    using the log file at project level
+    :return:
+    """
+    new_json_name = d_m_y + '_' + mapping_type + '.json'
+    orig_mapping = None
+    for res in XNAT.select(res_files).get():
+        if res.endswith('.json'):
+            res_obj = XNAT.select(os.path.join(res_files, res))
+            with open(res_obj.get(), "r+") as f:
+                prev_mapping = json.load(f)
+                f.seek(0, 0)
+                orig_mapping = json.load(f)
+
+                with open(XNAT.select(os.path.join(res_files, 'LOGFILE.txt')).get(), "r+") as lf:
+                    lines = lf.readlines()
+                    lines.reverse()
+                    for l in lines:
+                        if not l.startswith(OPTIONS.revert):
+                            mapping_all = l.split(",")
+                            if mapping_all[1].strip() == '+':
+                                prev_mapping[project].pop(mapping_all[2].split(':')[0].strip())
+                            if mapping_all[1].strip() == '-':
+                                prev_mapping[project].update({mapping_all[2].split(':')[0].
+                                                             strip(): mapping_all[2].split(':')[1].strip()})
+                        else:
+                            break
+                findDiff_change(prev_mapping, orig_mapping)
+            XNAT.select(os.path.join(res_files, new_json_name)).put(src=json.dumps(prev_mapping, indent=2))
+            res_obj.delete()
+            LOGGER.info('REVERTED: changed mapping file %s' % new_json_name,)
+
+
+def findDiff(d1, d2, path=""):
+    """
+    Function to record/log the changing made when adding rules
+    :param d1: dict with new mapping
+    :param d2: dict with old mapping
+    :param path: ""
+    :return:
+    """
+    for k, v in d1.items():
+        if k not in list(d2.keys()):
+            row1 = d_m_y, " + ", k + " : " + v
+            CSVWRITER.writerow(row1)
+        else:
+            if type(d1[k]) is dict:
+                if path == "":
+                    path = k
+                else:
+                    path = path + "->" + k
+                findDiff(d1[k], d2[k], path)
+            else:
+                if d1[k] != d2[k]:
+                    row2 = d_m_y, " - ", k + " : " + d2[k]
+                    CSVWRITER.writerow(row2)
+                    row3 = d_m_y, " + ", k + " : " + d1[k]
+                    CSVWRITER.writerow(row3)
+
+
+def findDiff_change(d1, d2, path=""):
+    """
+    Function to record/log the changing made when reverting rules
+    :param d1: dict with new mapping
+    :param d2: dict with previous mapping
+    :param path: ""
+    :return:
+    """
+    for d1_k, d1_v in d1.items():
+        for k, v in d1[d1_k].items():
+            row4 = d_m_y, " + ", k + " : " + v
+            CSVWRITER.writerow(row4)
+    for d2_k, d2_v in d1.items():
+        for k, v in d2[d2_k].items():
+            row5 = d_m_y, " - ", k + " : " + v
+            CSVWRITER.writerow(row5)
+
+
+
+
+def mapping_download():
+    """
+    Function to download the mapping file at project level
+    :return:
+    """
+    download_file = OPTIONS.download
+    download_dir = os.path.join(os.getcwd(), download_file)
+    os.makedirs(download_dir)
+    XNAT.select('/projects/' + project + '/resources/BIDS_' + mapping_type + '/').get(
+                 dest_dir=download_dir)
+    LOGGER.info('DOWNLOADED: %s mapping file at %s' % (mapping_type, download_dir))
+
+
+if __name__ == '__main__':
+    parser = add_parser_args()
+    OPTIONS = parser.parse_args()
+    if OPTIONS.host:
+        HOST = OPTIONS.host
+    else:
+        HOST = os.environ['XNAT_HOST']
+    if OPTIONS.username:
+        MSG = "Please provide the password for user <%s> on xnat(%s):"
+        PWD = getpass.getpass(prompt=MSG % (OPTIONS.username, HOST))
+    else:
+        PWD = None
+    LOGGER = setup_info_logger('BidsMapping', OPTIONS.logfile)
+    MSG = 'INFO: connection to xnat <%s>:' % (HOST)
+    LOGGER.info(MSG)
+    XNAT = XnatUtils.get_interface(host=OPTIONS.host,
+                                 user=OPTIONS.username,
+                                 pwd=PWD)
+    date = datetime.now()
+    d_m_y = date.strftime("%m-%d-%y-%H:%M:%S")
+
+    if not OPTIONS.project:
+        LOGGER.info("WARNING: Project is require. Use --project")
+    else:
+        project = OPTIONS.project
+        if OPTIONS.template:
+            template()
+        else:
+            xnat_type_file = XNAT.select('/data/projects/' + project + '/resources/BIDS_xnat_type/files/xnat_type.txt')
+            if not OPTIONS.xnatinfo:
+                LOGGER.info("WARNING: Xnatinfo is required. Use --xnatinfo")
+            elif OPTIONS.xnatinfo not in ["scan_type", "series_description"]:
+                LOGGER.error("ERROR: Type must be scan_type or series_description")
+            else:
+                xnat_type = OPTIONS.xnatinfo
+                LOGGER.info("The info used from XNAT is " + xnat_type)
+                xnat_type_file.put(src=xnat_type, overwrite=True)
+                XNAT.select(os.path.join('/data/projects/' + project + '/resources/', 'LOGFILE.txt'))
+                if not OPTIONS.type:
+                    LOGGER.info("WARNING: Type is required. Use --type")
+                elif OPTIONS.type not in ["datatype", "tasktype", "repetition_time_sec"]:
+                    LOGGER.error("ERROR: Type must be datatype or tasktype or repetition_time_sec")
+                else:
+                    mapping_type = OPTIONS.type
+                    CSVWRITER = None
+                    res_files = '/data/projects/' + project + '/resources/BIDS_' + mapping_type + '/files'
+                    xnat_logfile = XNAT.select(os.path.join(res_files, 'LOGFILE.txt'))
+                    if not xnat_logfile.exists():
+                        if OPTIONS.revert:
+                            LOGGER.error('Cannot perform --revert. Create mapping with --create option first')
+                            sys.exit()
+                        xnat_logfile.put(src="Logfile\n")
+                    LOGFILE = xnat_logfile.get()
+                    csvfilewrite = open(LOGFILE, 'ab')
+                    CSVWRITER = csv.writer(csvfilewrite, delimiter=',')
+                    if OPTIONS.create:
+                        create()
+                    if OPTIONS.create_default:
+                        default()
+                    if OPTIONS.update or OPTIONS.replace:
+                        update()
+                    if OPTIONS.revert:
+                        revert()
+                    if OPTIONS.download:
+                        mapping_download()
+
+                    csvfilewrite.close()
+                    XNAT.select(os.path.join(res_files, 'LOGFILE.txt')).put(src=LOGFILE, overwrite=True)

--- a/bin/Xnat_tools/BIDSMapping
+++ b/bin/Xnat_tools/BIDSMapping
@@ -16,7 +16,6 @@ import argparse
 from dax import XnatUtils
 from datetime import datetime
 
-
 def add_parser_args():
     """
     Method to parse all the arguments for the tool on ArgumentParser
@@ -71,6 +70,78 @@ def add_parser_args():
                       help='Default mapping template (EG: --template <template file>)')
 
     return argp
+
+def main_display():
+    """
+    Main display for the tool
+    """
+    print('################################################################')
+    print('#                         BIDSMAPPING                          #')
+    print('#                                                              #')
+    print('# Developed by the MASI Lab Vanderbilt University, TN, USA.    #')
+    print('# If issues, please start a thread here:                       #')
+    print('# https://groups.google.com/forum/#!forum/vuiis-cci            #')
+    print('# Usage:                                                       #')
+    print('#     Upload rules/mapping to Project level on XNAT            #')
+    print('# Parameters :                                                 #')
+
+    if OPTIONS.host:
+        print('#     %*s -> %*s#' % (
+            -20, 'XNAT Host', -33, get_proper_str(OPTIONS.host)))
+    if OPTIONS.username:
+        print('#     %*s -> %*s#' % (
+            -20, 'XNAT User', -33, get_proper_str(OPTIONS.username)))
+    if OPTIONS.project:
+        print('#     %*s -> %*s#' % (
+            -20, 'Project ID',
+            -33, get_proper_str(OPTIONS.project)))
+    if OPTIONS.xnatinfo:
+        print('#     %*s -> %*s#' % (
+            -20, 'XNAT mapping type',
+            -33, get_proper_str(OPTIONS.xnatinfo, True)))
+    if OPTIONS.type:
+        print('#     %*s -> %*s#' % (
+            -20, 'BIDS mapping type',
+            -33, get_proper_str(OPTIONS.type, True)))
+    if OPTIONS.create_default:
+        print('#     %*s -> %*s#' % (-20, 'Create default mode', -33, 'on'))
+    if OPTIONS.create:
+        print('#     %*s -> %*s#' % (
+            -20, 'Create mapping with',
+            -33, get_proper_str(OPTIONS.create, True)))
+    if OPTIONS.update:
+        print('#     %*s -> %*s#' % (
+            -20, 'Update mapping with',
+            -33, get_proper_str(OPTIONS.update, True)))
+    if OPTIONS.replace:
+        print('#     %*s -> %*s#' % (
+            -20, 'Replace mapping with',
+            -33, get_proper_str(OPTIONS.replace, True)))
+    if OPTIONS.revert:
+        print('#     %*s -> %*s#' % (
+            -20, 'Revert mapping to',
+            -33, get_proper_str(OPTIONS.revert, True)))
+    if OPTIONS.download:
+        print('#     %*s -> %*s#' % (
+            -20, 'Download current mapping to',
+            -33, get_proper_str(OPTIONS.download, True)))
+    print('################################################################')
+
+def get_proper_str(str_option, end=False):
+    """
+    Method to shorten a string into the proper size for display
+
+    :param str_option: string to shorten
+    :param end: keep the end of the string visible (default beginning)
+    :return: shortened string
+    """
+    if len(str_option) > 32:
+        if end:
+            return '...' + str_option[-29:]
+        else:
+            return str_option[:29] + '...'
+    else:
+        return str_option
 
 def setup_info_logger(name, logfile):
     """
@@ -390,6 +461,7 @@ def mapping_download():
 if __name__ == '__main__':
     parser = add_parser_args()
     OPTIONS = parser.parse_args()
+    main_display()
     if OPTIONS.host:
         HOST = OPTIONS.host
     else:

--- a/bin/Xnat_tools/Xnatdownload
+++ b/bin/Xnat_tools/Xnatdownload
@@ -71,6 +71,9 @@ Examples:
 --rs NIFTI --overwrite
    *Download data described by a csvfile (follow template) :
         Xnatdownload -d /tmp/downloadPID -c  upload_sheet.csv
+   *Transform the XnatDownload data in BIDS format for all sessions, scantype and resources:
+        Xnatdownload -p PID --sess all -d /tmp/downloadPID -s all --rs all \
+--bids --bids_dir /tmp/BIDS_dataset
 """
 
 

--- a/bin/Xnat_tools/Xnatdownload
+++ b/bin/Xnat_tools/Xnatdownload
@@ -24,6 +24,7 @@ import shutil
 import getpass
 import logging
 from dax import XnatUtils
+from dax import XnatToBids
 from datetime import datetime
 
 
@@ -1031,6 +1032,11 @@ specified. Use -s or --WOS.')
         print('OPTION ERROR: resources selected for assessors but no types \
 specified. Use -a or --WOA.')
         return False
+    # Check BIDS direcotry given
+    if OPTIONS.xnat2bids and not OPTIONS.bids_dir:
+        print('OPTION ERROR: BIDS directory not specified. Use option \
+--bids_dir.')
+        return False
     return True
 
 
@@ -1148,6 +1154,13 @@ def main_display():
             print('#     %*s -> %*s#' % (-20, 'Overwrite mode', -33, 'on'))
         if OPTIONS.update:
             print('#     %*s -> %*s#' % (-20, 'Update mode', -33, 'on'))
+        # BIDS
+        if OPTIONS.xnat2bids:
+            print('#     %*s -> %*s#' % (-20, 'XNAT to BIDS mode', -33, 'on'))
+        if OPTIONS.bids_dir:
+            print('#     %*s -> %*s#' % (
+                -20, 'BIDS Directory',
+                -33, get_proper_str(OPTIONS.bids_dir, True)))
         if OPTIONS.outputfile:
             print('#     %*s -> %*s#' % (
                 -20, 'Output file',
@@ -1267,6 +1280,12 @@ OPTIONS.")
     # Ignore csv
     argp.add_argument("-i", "--ignore", dest="ignorecsv", action='store_true',
                       help="Ignore reading of the csv report file")
+    #BIDS
+    argp.add_argument("-b", "--bids", dest="xnat2bids", action='store_true',
+                      help="Transform to BIDS format after XNAT download")
+
+    argp.add_argument("--bids_dir", dest="bids_dir", default=None,
+                      help="Directory to store the bids dataset")
     return argp
 
 

--- a/bin/Xnat_tools/Xnatdownload
+++ b/bin/Xnat_tools/Xnatdownload
@@ -1336,5 +1336,10 @@ scans.')
                 else:
                     CSVWRITER = None
                     download_data_xnat()
+        if OPTIONS.xnat2bids:
+            project = OPTIONS.project
+            BIDS_DIR = OPTIONS.bids_dir
+            # TRANFOMR XNAT2BIDS REFACTOR
+            XnatToBids.transform_to_bids(XNAT, DIRECTORY, project, BIDS_DIR, LOGGER)
 
     LOGGER.info('============================================================')

--- a/dax/XnatToBids.py
+++ b/dax/XnatToBids.py
@@ -139,8 +139,8 @@ def bids_yaml(XNAT, project, scan_id, subj, res_dir, scan_file, uri, sess, nii_f
 
     else:
         # If datatype is know, Create the BIDS directory and do the rest
-        sess_idx = "{0:0=2d}".format(sess_idx)
-        subj_idx = "{0:0=2d}".format(subj_idx)
+        sess_idx = "{0:0=2d}".format(int(sess_idx))
+        subj_idx = "{0:0=2d}".format(int(subj_idx))
         bids_dir = os.path.join(res_dir, "BIDS_DATA")
         if not os.path.exists(bids_dir):
             os.makedirs(bids_dir)

--- a/dax/XnatToBids.py
+++ b/dax/XnatToBids.py
@@ -1,0 +1,397 @@
+'''
+Tranform XNAT folder to BIDS format
+
+@author: Praitayini Kanakaraj, Electrical Engineering, Vanderbilt University
+
+'''
+import os
+import re
+import sys
+import json
+import shutil
+import nibabel as nib
+from distutils.dir_util import copy_tree
+from xml.etree import cElementTree as ET
+
+
+def transform_to_bids(XNAT, DIRECTORY, project, BIDS_DIR, LOGGER):
+    """
+     Method to move the data from XNAT folders to BIDS format (based on datatype) by looping through
+     subjects/projects.
+
+     :return: None
+     """
+    LOGGER.info("--------------- BIDS --------------")
+    LOGGER.info("INFO: Moving files to the BIDS folder...")
+    # sd_dict = sd_datatype_mapping(XNAT, project)
+    data_type_l = ["anat", "func", "fmap", "dwi", "unknown_bids"]
+    subj_idx = 1
+    sess_idx = 1
+    # project_scans = XNAT.get_project_scans(project)
+    for proj in os.listdir(DIRECTORY):
+        if proj == project and os.path.isdir(os.path.join(DIRECTORY, proj)):
+            for subj in os.listdir(os.path.join(DIRECTORY, proj)):
+                # subj_idx = 1
+                LOGGER.info("* Subject %s" % (subj))
+                for sess in os.listdir(os.path.join(DIRECTORY, proj, subj)):
+                    LOGGER.info(" * Session %s" % (sess))
+                    sess_path = os.path.join(DIRECTORY, proj, subj, sess)
+                    # sess_idx = 1
+                    for scan in os.listdir(sess_path):
+                        if scan not in data_type_l:
+                            for scan_resources in os.listdir(os.path.join(sess_path, scan)):
+                                for scan_file in os.listdir(os.path.join(sess_path, scan, scan_resources)):
+                                    scan_id = scan.split('-x-')[0]
+                                    res_dir = (os.path.join(sess_path, scan, scan_resources))
+                                    scan_path = '/projects/%s/subjects/%s/experiments/%s/scans/%s' % (
+                                    project, subj, sess, scan.split('-x-')[0])
+                                    scan_info = XNAT.select(scan_path)
+                                    uri = XNAT.host + scan_info._uri
+                                    if scan_file.endswith('.nii.gz'):
+                                        LOGGER.info("  * Scan File %s" % (scan_file))
+                                        nii_file = scan_file
+                                        bids_yaml(XNAT, project, scan_id, subj, res_dir, scan_file, uri, sess, nii_file,
+                                                  sess_idx, subj_idx)
+                                        if not os.path.exists(os.path.join(BIDS_DIR, project)):
+                                            os.makedirs(os.path.join(BIDS_DIR, project))
+                                        copy_tree(os.path.join(res_dir, "BIDS_DATA"), os.path.join(BIDS_DIR, project))
+                                        shutil.rmtree(os.path.join(res_dir, "BIDS_DATA"))
+                            LOGGER.info("\t\t>Removing XNAT resource %s folder" % (scan_resources))
+                            os.rmdir(os.path.join(sess_path, scan, scan_resources))
+                            os.rmdir(os.path.join(sess_path, scan))
+                    sess_idx = sess_idx + 1
+                    LOGGER.info("\t>Removing XNAT session %s folder" % (sess))
+                    # shutil.rmtree(sess_path)
+                    os.rmdir(sess_path)
+                subj_idx = subj_idx + 1
+                LOGGER.info("\t>Removing XNAT subject %s folder" % (subj))
+                os.rmdir(os.path.join(DIRECTORY, proj, subj))
+    dataset_description_file(BIDS_DIR, XNAT, project)
+
+
+def bids_yaml(XNAT, project, scan_id, subj, res_dir, scan_file, uri, sess, nii_file, sess_idx, subj_idx):
+    is_json_present = False
+    if nii_file.split('.')[0] + ".json" in os.listdir(res_dir):
+        json_file = nii_file.split('.')[0] + ".json"
+        is_json_present = True
+    else:
+        json_file = "empty.json"
+    sd_dict = sd_datatype_mapping(XNAT, project)
+    project_scans = XNAT.get_project_scans(project)
+    # for x in project_scans:
+    #    if x['ID'] == scan_id and x['subject_label'] == subj:
+    #        scan_type = x['type']
+    #        series_description = x['series_description']
+    if XNAT.select('/data/projects/' + project + '/resources/BIDS_xnat_type/files/xnat_type.txt').exists:
+        with open(XNAT.select('/data/projects/' + project + '/resources/BIDS_xnat_type/files/xnat_type.txt').get(),
+                  "r+") as f:
+            xnat_mapping_type = f.read()
+            print(xnat_mapping_type)
+            for x in project_scans:
+                if x['ID'] == scan_id and x['subject_label'] == subj and xnat_mapping_type == 'scan_type':
+                    xnat_mapping_type = x['type']
+                elif x['ID'] == scan_id and x['subject_label'] == subj and xnat_mapping_type == 'series_description':
+                    xnat_mapping_type = x['series_description']
+            print(xnat_mapping_type)
+    else:
+        print(
+            "ERROR: The type of xnat map info (for eg. scan_type or series_description) is not given. Use BidsMapping Tool")
+        sys.exit()
+
+    data_type = sd_dict.get(xnat_mapping_type, "unknown_bids")
+    if data_type == "unknown_bids":
+        print((
+            "WARNING: The type %s does not have a BIDS datatype mapping at default and project level. Use BidsMapping Tool" % xnat_mapping_type))
+
+        # sys.exit()
+    xnat_prov = yaml_create_json(XNAT, data_type, res_dir, scan_file, uri, project, xnat_mapping_type, sess,
+                                 is_json_present,
+                                 nii_file, json_file)
+    sess_idx = "{0:0=2d}".format(sess_idx)
+    subj_idx = "{0:0=2d}".format(subj_idx)
+    bids_fname = yaml_bids_filename(XNAT, data_type, scan_id, subj, sess, project, scan_file, xnat_mapping_type,
+                                    sess_idx, subj_idx)
+    bids_fname_json = yaml_bids_filename(XNAT, data_type, scan_id, subj, sess, project, json_file, xnat_mapping_type,
+                                         sess_idx, subj_idx)
+    with open(os.path.join(res_dir, json_file), "w+") as f:
+        json.dump(xnat_prov, f, indent=2)
+    os.rename(os.path.join(res_dir, nii_file), os.path.join(res_dir, bids_fname))
+    os.rename(os.path.join(res_dir, json_file), os.path.join(res_dir, bids_fname_json))
+    bids_dir = os.path.join(res_dir, "BIDS_DATA")
+    if not os.path.exists(bids_dir):
+        os.makedirs(bids_dir)
+    data_type_dir = os.path.join(bids_dir, "sub-" + subj_idx, "ses-" + sess_idx, data_type)
+    if not os.path.exists(os.path.join(bids_dir, data_type_dir)):
+        os.makedirs(os.path.join(bids_dir, data_type_dir))
+    # for res in os.listdir(res_dir):
+    #     if os.path.isfile(os.path.join(res_dir,res)):
+    # print "Moving %s and %s" % (os.path.join(res_dir, nii_file), os.path.join(res_dir, json_file))
+    shutil.move(os.path.join(res_dir, bids_fname), data_type_dir)
+    shutil.move(os.path.join(res_dir, bids_fname_json), data_type_dir)
+
+
+def yaml_bids_filename(XNAT, data_type, scan_id, subj, sess, project, scan_file, xnat_mapping_type, sess_idx, subj_idx):
+    if data_type == "anat":
+        bids_fname = "sub-" + subj_idx + '_' + "ses-" + sess_idx + '_acq-' + scan_id + '_' + 'T1w' + \
+                     '.' + ".".join(scan_file.split('.')[1:])
+
+        return bids_fname
+    elif data_type == "func":
+        tk_dict = sd_tasktype_mapping(XNAT, project)
+        task_type = tk_dict.get(xnat_mapping_type)
+        if task_type == None:
+            print(('ERROR: Scan type %s does not have a BIDS tasktype mapping at default and project level ' \
+                  'Use BidsMapping tool. Func folder not created' % xnat_mapping_type))
+            # func_folder = os.path.join(bids_sess_path, data_type)
+            # os.rmdir(func_folder)
+            sys.exit()
+
+        bids_fname = "sub-" + subj_idx + '_' + "ses-" + sess_idx + '_task-' + task_type + '_acq-' + scan_id + '_run-01' \
+                     + '_' + 'bold' + '.' + ".".join(scan_file.split('.')[1:])
+        return bids_fname
+    elif data_type == "dwi":
+        if label == "BVEC":
+            bids_fname = "sub-" + subj_idx + '_' + "ses-" + sess_idx + '_acq-' + scan_id + '_' + 'dwi' + '.' + 'bvec'
+
+        elif label == "BVAL":
+            bids_fname = "sub-" + subj_idx + '_' + "ses-" + sess_idx + '_acq-' + scan_id + '_' + 'dwi' + '.' + 'bval'
+
+        else:
+            bids_fname = "sub-" + subj_idx + '_' + "ses-" + sess_idx + '_acq-' + scan_id + '_' + 'dwi' + \
+                         '.' + ".".join(scan_file.split('.')[1:])
+        return bids_fname
+
+    elif data_type == "fmap":
+        bids_fname = "sub-" + subj_idx + '_' + "ses-" + sess_idx + '_acq-' + scan_id + '_bold' + \
+                     '.' + ".".join(scan_file.split('.')[1:])
+        return bids_fname
+
+
+def yaml_create_json(XNAT, data_type, res_dir, scan_file, uri, project, xnat_mapping_type, sess, is_json_present,
+                     nii_file,
+                     json_file):
+    if data_type != 'func':
+        xnat_detail = {"XNATfilename": scan_file,
+                       "XNATProvenance": uri}
+        if not is_json_present:
+            print('\t\t>No json sidecar. Created json sidecar with xnat info.')
+            xnat_prov = xnat_detail
+        else:
+            # print os.path.join(res_dir, json_file)
+            with open(os.path.join(res_dir, json_file), "r+") as f:
+                print('\t\t>Json sidecar exists. Added xnat info.')
+                xnat_prov = json.load(f)
+                xnat_prov.update(xnat_detail)
+                # file.seek(0)
+                # json.dump(xnat_prov, f, indent=2)
+                # print xnat_prov
+
+    else:
+        xnat_prov = yaml_func_json_sidecar(XNAT, data_type, res_dir, scan_file, uri, project, xnat_mapping_type,
+                                           nii_file,
+                                           is_json_present, sess, json_file)
+        # print xnat_prov
+    return xnat_prov
+
+
+def yaml_func_json_sidecar(XNAT, data_type, res_dir, scan_file, uri, project, xnat_mapping_type, nii_file,
+                           is_json_present,
+                           sess, json_file):
+    xnat_prov = None
+    tr_dict = sd_tr_mapping(XNAT, project)
+    TR_bidsmap = tr_dict.get(xnat_mapping_type)
+    if TR_bidsmap == None:
+        print(('\t\t>ERROR: Scan type %s does not have a TR mapping' % xnat_mapping_type))
+        # func_folder = os.path.dirname(bids_res_path)
+        # os.rmdir(func_folder)
+        sys.exit()
+    TR_bidsmap = round((float(TR_bidsmap)), 3)
+    tk_dict = sd_tasktype_mapping(XNAT, project)
+    task_type = tk_dict.get(xnat_mapping_type)
+    img = nib.load(os.path.join(res_dir, nii_file))
+    units = img.header.get_xyzt_units()[1]
+    if units != 'sec':
+        print("\t\t>ERROR: the units in nifti header is not secs")
+        func_folder = os.path.dirname(bids_res_path)
+        os.rmdir(func_folder)
+        sys.exit()
+    TR_nifti = round((img.header['pixdim'][4]), 3)
+    if not is_json_present:
+        xnat_prov = {"XNATfilename": scan_file,
+                     "XNATProvenance": uri,
+                     "TaskName": task_type}
+        if TR_nifti == TR_bidsmap:
+            print((
+                '\t\t>No existing json. TR %.3f sec in BIDS mapping and NIFTI header. Using TR %.3f sec in nifti header ' \
+                'for scan file %s in session %s. ' % (TR_bidsmap, TR_bidsmap, scan_file, sess)))
+            xnat_prov["RepetitionTime"] = TR_nifti
+        else:
+            print((
+                '\t\t>No existing json. WARNING: The TR is %.3f sec in project level BIDS mapping, which does not match the TR of %.3f sec in NIFTI header.\n  ' \
+                '\t\tUPDATING NIFTI HEADER to match BIDS mapping TR %.3f sec for scan file %s in session %s.' \
+                % (TR_bidsmap, TR_nifti, TR_bidsmap, scan_file, sess)))
+            xnat_prov["RepetitionTime"] = TR_bidsmap
+            img.header['pixdim'][4] = TR_bidsmap
+            nib.save(img, os.path.join(res_dir, nii_file))
+    else:
+        with open(os.path.join(res_dir, json_file), "r+") as f:
+            xnat_prov = json.load(f)
+            TR_json = round((xnat_prov['RepetitionTime']), 3)
+            xnat_detail = {"XNATfilename": scan_file,
+                           "XNATProvenance": uri,
+                           "TaskName": task_type}
+            if TR_json != TR_bidsmap:
+                print((
+                    '\t\t>JSON sidecar exists. WARNING: TR is %.3f sec in project level BIDS mapping, which does not match the TR in JSON sidecar %.3f.\n ' \
+                    '\t\tUPDATING JSON with TR %.3f sec in BIDS mapping and UPDATING NIFTI header for scan %s in session %s.' \
+                    % (TR_bidsmap, TR_json, TR_bidsmap, scan_file, sess)))
+                xnat_detail['RepetitionTime'] = TR_bidsmap
+                xnat_prov.update(xnat_detail)
+                img.header['pixdim'][4] = TR_bidsmap
+                nib.save(img, os.path.join(res_dir, nii_file))
+            else:
+                print((
+                    '\t\t>JSON sidecar exists. TR is %.3f sec in BIDS mapping and JSON sidecar for scan %s in session %s. ' \
+                    'Created json sidecar with XNAT info' \
+                    % (TR_bidsmap, scan_file, sess)))
+                xnat_prov.update(xnat_detail)
+    return xnat_prov
+
+
+def sd_tr_mapping(XNAT, project):
+    tr_dict = {}
+    if XNAT.select('/data/projects/' + project + '/resources/BIDS_repetition_time_sec').exists():
+        for res in XNAT.select('/data/projects/' + project + '/resources/BIDS_repetition_time_sec/files').get():
+            if res.endswith('.json'):
+                with open(XNAT.select(
+                        '/data/projects/' + project + '/resources/BIDS_repetition_time_sec/files/' + res).get(),
+                          "r+") as f:
+                    tr_mapping = json.load(f)
+                    print(('\t\t>Using BIDS Repetition Time in secs mapping in project level %s' % (project)))
+                    tr_dict = tr_mapping[project]
+                    # tr_dict = {k.strip().replace('/', '_').replace(" ", "").replace(":", '_')
+                    #: v for k, v in tr_dict.items()}
+    else:
+        print("\t\t>ERROR: no TR mapping at project level. Func folder not created")
+        # func_folder = os.path.dirname(bids_res_path)
+        # os.rmdir(func_folder)
+        sys.exit()
+    return tr_dict
+
+
+def sd_datatype_mapping(XNAT, project):
+    """
+      Method to map scan type to task type for functional scans
+
+      :return: mapping dict
+    """
+    sd_dict = {}
+    # if OPTIONS.selectionScan:
+    # project = OPTIONS.selectionScan.split('-')[0]
+    # else:
+    # project = OPTIONS.project
+    if XNAT.select('/data/projects/' + project + '/resources/BIDS_datatype').exists():
+        for res in XNAT.select('/data/projects/' + project + '/resources/BIDS_datatype/files').get():
+            if res.endswith('.json'):
+                with open(XNAT.select('/data/projects/' + project + '/resources/BIDS_datatype/files/' + res).get(),
+                          "r+") as f:
+                    datatype_mapping = json.load(f)
+                    sd_dict = datatype_mapping[project]
+                    print(('\t\t>Using BIDS datatype mapping in project level %s' % (project)))
+                    # sd_dict = {k.strip().replace('/', '_').replace(" ", "").replace(":", '_')
+                    #: v for k, v in sd_dict.items()}
+    else:
+        print(('\t\t>WARNING: No BIDS datatype mapping in project %s - using default mapping' % (project)))
+        # LOGGER.info('WARNING: No BIDS datatype mapping in project %s - using default mapping' % (project))
+        scans_list_global = XNAT.get_project_scans('LANDMAN')
+
+        for sd in scans_list_global:
+            c = re.search('T1|T2|T1W', sd['scan_type'])
+            if not c == None:
+                sd_anat = sd['scan_type'].strip().replace('/', '_').replace(" ", "").replace(":", '_')
+                sd_dict[sd_anat] = "anat"
+
+        for sd in scans_list_global:
+            c = re.search('rest|Resting state|Rest', sd['scan_type'], flags=re.IGNORECASE)
+            if not c == None:
+                sd_func = sd['scan_type'].strip().replace('/', '_').replace(" ", "").replace(":", '_')
+                sd_dict[sd_func] = "func"
+
+        for sd in scans_list_global:
+            c = re.search('dwi|dti', sd['scan_type'], flags=re.IGNORECASE)
+            if not c == None:
+                sd_dwi = sd['scan_type'].strip().replace('/', '_').replace(" ", "").replace(":", '_')
+                sd_dict[sd_dwi] = "dwi"
+
+        for sd in scans_list_global:
+            c = re.search('Field|B0', sd['scan_type'], flags=re.IGNORECASE)
+            if not c == None:
+                sd_fmap = sd['scan_type'].strip().replace('/', '_').replace(" ", "").replace(":", '_')
+                sd_dict[sd_fmap] = "fmap"
+        with open("global_mapping.json", "w+") as f:
+            json.dump(sd_dict, f, indent=2)
+
+    return sd_dict
+
+
+def sd_tasktype_mapping(XNAT, project):
+    """
+     Method to map scan type to task type for functional scans
+
+     :return: mapping dict
+     """
+    tk_dict = {}
+    # project = OPTIONS.project
+    if XNAT.select('/data/projects/' + project + '/resources/BIDS_tasktype').exists():
+        for res in XNAT.select('/data/projects/' + project + '/resources/BIDS_tasktype/files').get():
+            if res.endswith('.json'):
+                with open(XNAT.select('/data/projects/' + project + '/resources/BIDS_tasktype/files/'
+                                      + res).get(), "r+") as f:
+                    datatype_mapping = json.load(f)
+                    # print "\t\t>Using tasktype mapping in project level %s" % (project)
+                    tk_dict = datatype_mapping[project]
+                    # tk_dict = {k.strip().replace('/', '_').replace(" ", "").replace(":", '_')
+                    #: v for k, v in tk_dict.items()}
+
+    else:
+        print(('\t\t>WARNING: No BIDS task type mapping in project %s - using default mapping' % (project)))
+        scans_list_global = XNAT.get_project_scans('LANDMAN')
+        for sd in scans_list_global:
+            c = re.search('rest|Resting state|Rest', sd['scan_type'], flags=re.IGNORECASE)
+            if not c == None:
+                sd_func = sd['scan_type'].strip().replace('/', '_').replace(" ", "").replace(":", '_')
+                tk_dict[sd_func] = "rest"
+        with open("global_tk_mapping.json", "w+") as f:
+            json.dump(tk_dict, f, indent=2)
+    return tk_dict
+
+
+def dataset_description_file(BIDS_DIR, XNAT, project):
+    """
+    Build BIDS dataset description json file
+
+    :return: None
+    """
+
+    BIDSVERSION = "1.0.1"
+    dataset_description = dict()
+    dataset_description['BIDSVersion'] = BIDSVERSION
+    dataset_description['Name'] = project
+    dataset_description['DatasetDOI'] = XNAT.host
+    project_info = XNAT.select('/project/' + project).get()
+    project_info = ET.fromstring(project_info)
+    PI_element = project_info.findall('{http://nrg.wustl.edu/xnat}PI')
+    if len(PI_element) > 0:
+        dataset_description['Author'] = PI_element[0][1].text, PI_element[0][0].text
+    else:
+        dataset_description['Author'] = "No Author defined on XNAT"
+    dd_file = os.path.join(BIDS_DIR, project)
+    if not os.path.exists(dd_file):
+        os.makedirs(dd_file)
+    with open(os.path.join(dd_file, 'dataset_description.json'), 'w+') as f:
+        json.dump(dataset_description, f, indent=2)
+
+
+
+
+

--- a/dax/XnatToBids.py
+++ b/dax/XnatToBids.py
@@ -16,27 +16,28 @@ from xml.etree import cElementTree as ET
 
 def transform_to_bids(XNAT, DIRECTORY, project, BIDS_DIR, LOGGER):
     """
-     Method to move the data from XNAT folders to BIDS format (based on datatype) by looping through
-     subjects/projects.
-
-     :return: None
-     """
+    Method to move the data from XNAT folders to BIDS format (based on datatype) by looping through
+    subjects/projects.
+    :param XNAT: XNAT interface (connection between your python script and the XNAT database)
+    :param DIRECTORY: XNAT Directory
+    :param project: XNAT Project ID
+    :param BIDS_DIR: BIDS Directory
+    :param LOGGER: Logging
+    """
     LOGGER.info("--------------- BIDS --------------")
     LOGGER.info("INFO: Moving files to the BIDS folder...")
-    # sd_dict = sd_datatype_mapping(XNAT, project)
+    # All the BIDS datattype
     data_type_l = ["anat", "func", "fmap", "dwi", "unknown_bids"]
-    subj_idx = 1
-    sess_idx = 1
-    # project_scans = XNAT.get_project_scans(project)
+    # Loop throught the XNAT folders
     for proj in os.listdir(DIRECTORY):
         if proj == project and os.path.isdir(os.path.join(DIRECTORY, proj)):
+            subj_idx = 1
             for subj in os.listdir(os.path.join(DIRECTORY, proj)):
-                # subj_idx = 1
                 LOGGER.info("* Subject %s" % (subj))
+                sess_idx = 1
                 for sess in os.listdir(os.path.join(DIRECTORY, proj, subj)):
                     LOGGER.info(" * Session %s" % (sess))
                     sess_path = os.path.join(DIRECTORY, proj, subj, sess)
-                    # sess_idx = 1
                     for scan in os.listdir(sess_path):
                         if scan not in data_type_l:
                             for scan_resources in os.listdir(os.path.join(sess_path, scan)):
@@ -47,21 +48,34 @@ def transform_to_bids(XNAT, DIRECTORY, project, BIDS_DIR, LOGGER):
                                     project, subj, sess, scan.split('-x-')[0])
                                     scan_info = XNAT.select(scan_path)
                                     uri = XNAT.host + scan_info._uri
-                                    if scan_file.endswith('.nii.gz'):
+                                    # Do the BIDS conversion for only nifti, bval, bval scans
+                                    if scan_file.endswith('.nii.gz') or scan_file.endswith(
+                                            'bvec.txt') or scan_file.endswith('bval.txt') or scan_file.endswith(
+                                            'bvec') or scan_file.endswith('bval'):
                                         LOGGER.info("  * Scan File %s" % (scan_file))
                                         nii_file = scan_file
+                                        # Call the main BIDS function that is compatible with yaml
                                         bids_yaml(XNAT, project, scan_id, subj, res_dir, scan_file, uri, sess, nii_file,
                                                   sess_idx, subj_idx)
+                                        # Create the BIDS directory
                                         if not os.path.exists(os.path.join(BIDS_DIR, project)):
                                             os.makedirs(os.path.join(BIDS_DIR, project))
-                                        copy_tree(os.path.join(res_dir, "BIDS_DATA"), os.path.join(BIDS_DIR, project))
-                                        shutil.rmtree(os.path.join(res_dir, "BIDS_DATA"))
-                            LOGGER.info("\t\t>Removing XNAT resource %s folder" % (scan_resources))
-                            os.rmdir(os.path.join(sess_path, scan, scan_resources))
+                                        # Move the BIDS conversion inside the XNAT resource folder to BIDS folder and then delete
+                                        if os.path.exists(os.path.join(res_dir, "BIDS_DATA")):
+                                            copy_tree(os.path.join(res_dir, "BIDS_DATA"),
+                                                      os.path.join(BIDS_DIR, project))
+                                            shutil.rmtree(os.path.join(res_dir, "BIDS_DATA"))
+                                        else:
+                                            # Delete XNAT files/folders after BIDS Conversion
+                                            LOGGER.info("\t\t>Removing XNAT scan %s file because no BIDS datatype" % (
+                                                scan_file))
+                                            os.remove(os.path.join(sess_path, scan, scan_resources, scan_file))
+                                LOGGER.info("\t\t>Removing XNAT resource %s folder" % (scan_resources))
+                                os.rmdir(os.path.join(sess_path, scan, scan_resources))
+                            LOGGER.info("\t>Removing XNAT scan %s folder" % (scan))
                             os.rmdir(os.path.join(sess_path, scan))
                     sess_idx = sess_idx + 1
                     LOGGER.info("\t>Removing XNAT session %s folder" % (sess))
-                    # shutil.rmtree(sess_path)
                     os.rmdir(sess_path)
                 subj_idx = subj_idx + 1
                 LOGGER.info("\t>Removing XNAT subject %s folder" % (subj))
@@ -70,94 +84,132 @@ def transform_to_bids(XNAT, DIRECTORY, project, BIDS_DIR, LOGGER):
 
 
 def bids_yaml(XNAT, project, scan_id, subj, res_dir, scan_file, uri, sess, nii_file, sess_idx, subj_idx):
-    is_json_present = False
-    if nii_file.split('.')[0] + ".json" in os.listdir(res_dir):
-        json_file = nii_file.split('.')[0] + ".json"
-        is_json_present = True
-    else:
-        json_file = "empty.json"
-    sd_dict = sd_datatype_mapping(XNAT, project)
+    """
+    Main method to put the scans in the BIDS datatype folder, create json
+    sidecar and remane filenames based on the BIDS format.
+    :param XNAT: XNAT interface
+    :param project: XNAT project ID
+    :param scan_id: Scan ID of the scan on XNAT
+    :param subj: Subject of the scan on XNAT
+    :param res_dir: XNAT Resource directory
+    :param scan_file: Scan file
+    :param uri: Link of the scan on XNAT
+    :param sess: XNAT Session
+    :param nii_file: Scan file (for yaml it is $col1 in the INLIST )
+    :param sess_idx: Session count number
+    :param subj_idx: Subject count number
+    """
+    # Check if the json sidecar is present or not
+    if scan_file.endswith('.nii.gz'):
+        is_json_present = False
+        if nii_file.split('.')[0] + ".json" in os.listdir(res_dir):
+            json_file = nii_file.split('.')[0] + ".json"
+            is_json_present = True
+        else:
+            json_file = "empty.json"
+
+    # Get the series_description and scan_type of the scan in XNAT
     project_scans = XNAT.get_project_scans(project)
-    # for x in project_scans:
-    #    if x['ID'] == scan_id and x['subject_label'] == subj:
-    #        scan_type = x['type']
-    #        series_description = x['series_description']
-    if XNAT.select('/data/projects/' + project + '/resources/BIDS_xnat_type/files/xnat_type.txt').exists:
+    for x in project_scans:
+        if x['ID'] == scan_id and x['subject_label'] == subj:
+            scan_type = x['type']
+            series_description = x['series_description']
+    # Get the xnat_type from Project level
+    if XNAT.select('/data/projects/' + project + '/resources/BIDS_xnat_type/files/xnat_type.txt').exists():
         with open(XNAT.select('/data/projects/' + project + '/resources/BIDS_xnat_type/files/xnat_type.txt').get(),
                   "r+") as f:
             xnat_mapping_type = f.read()
-            print(xnat_mapping_type)
-            for x in project_scans:
-                if x['ID'] == scan_id and x['subject_label'] == subj and xnat_mapping_type == 'scan_type':
-                    xnat_mapping_type = x['type']
-                elif x['ID'] == scan_id and x['subject_label'] == subj and xnat_mapping_type == 'series_description':
-                    xnat_mapping_type = x['series_description']
-            print(xnat_mapping_type)
+            if xnat_mapping_type == 'scan_type':
+                xnat_mapping_type = scan_type
+            elif xnat_mapping_type == 'series_description':
+                xnat_mapping_type = series_description
+            # print(xnat_mapping_type)
     else:
         print(
             "ERROR: The type of xnat map info (for eg. scan_type or series_description) is not given. Use BidsMapping Tool")
+        print("ERROR: BIDS Conversion not complete")
         sys.exit()
 
+    # Get the datatype for the scan
+    sd_dict = sd_datatype_mapping(XNAT, project)
     data_type = sd_dict.get(xnat_mapping_type, "unknown_bids")
     if data_type == "unknown_bids":
         print((
-            "WARNING: The type %s does not have a BIDS datatype mapping at default and project level. Use BidsMapping Tool" % xnat_mapping_type))
+            '\t\t>WARNING: The type %s does not have a BIDS datatype mapping at default and project level. Use BidsMapping Tool' % xnat_mapping_type))
 
-        # sys.exit()
-    xnat_prov = yaml_create_json(XNAT, data_type, res_dir, scan_file, uri, project, xnat_mapping_type, sess,
-                                 is_json_present,
-                                 nii_file, json_file)
-    sess_idx = "{0:0=2d}".format(sess_idx)
-    subj_idx = "{0:0=2d}".format(subj_idx)
-    bids_fname = yaml_bids_filename(XNAT, data_type, scan_id, subj, sess, project, scan_file, xnat_mapping_type,
-                                    sess_idx, subj_idx)
-    bids_fname_json = yaml_bids_filename(XNAT, data_type, scan_id, subj, sess, project, json_file, xnat_mapping_type,
-                                         sess_idx, subj_idx)
-    with open(os.path.join(res_dir, json_file), "w+") as f:
-        json.dump(xnat_prov, f, indent=2)
-    os.rename(os.path.join(res_dir, nii_file), os.path.join(res_dir, bids_fname))
-    os.rename(os.path.join(res_dir, json_file), os.path.join(res_dir, bids_fname_json))
-    bids_dir = os.path.join(res_dir, "BIDS_DATA")
-    if not os.path.exists(bids_dir):
-        os.makedirs(bids_dir)
-    data_type_dir = os.path.join(bids_dir, "sub-" + subj_idx, "ses-" + sess_idx, data_type)
-    if not os.path.exists(os.path.join(bids_dir, data_type_dir)):
-        os.makedirs(os.path.join(bids_dir, data_type_dir))
-    # for res in os.listdir(res_dir):
-    #     if os.path.isfile(os.path.join(res_dir,res)):
-    # print "Moving %s and %s" % (os.path.join(res_dir, nii_file), os.path.join(res_dir, json_file))
-    shutil.move(os.path.join(res_dir, bids_fname), data_type_dir)
-    shutil.move(os.path.join(res_dir, bids_fname_json), data_type_dir)
+    else:
+        # If datatype is know, Create the BIDS directory and do the rest
+        sess_idx = "{0:0=2d}".format(sess_idx)
+        subj_idx = "{0:0=2d}".format(subj_idx)
+        bids_dir = os.path.join(res_dir, "BIDS_DATA")
+        if not os.path.exists(bids_dir):
+            os.makedirs(bids_dir)
+        data_type_dir = os.path.join(bids_dir, "sub-" + subj_idx, "ses-" + sess_idx, data_type)
+        if not os.path.exists(os.path.join(bids_dir, data_type_dir)):
+            os.makedirs(os.path.join(bids_dir, data_type_dir))
+        # For only nifti scans, handle json sidecar should be checked and the json sidecar filename should changed
+        if scan_file.endswith('.nii.gz'):
+            xnat_prov = yaml_create_json(XNAT, data_type, res_dir, scan_file, uri, project, xnat_mapping_type, sess,
+                                         is_json_present,
+                                         nii_file, json_file, series_description)
+            with open(os.path.join(res_dir, json_file), "w+") as f:
+                json.dump(xnat_prov, f, indent=2)
+            bids_fname_json = yaml_bids_filename(XNAT, data_type, scan_id, subj, sess, project, json_file,
+                                                 xnat_mapping_type, sess_idx, subj_idx, series_description)
+            os.rename(os.path.join(res_dir, json_file), os.path.join(res_dir, bids_fname_json))
+            shutil.move(os.path.join(res_dir, bids_fname_json), data_type_dir)
+
+        # Change the filename and move the file
+        bids_fname = yaml_bids_filename(XNAT, data_type, scan_id, subj, sess, project, scan_file, xnat_mapping_type,
+                                        sess_idx, subj_idx, series_description)
+        os.rename(os.path.join(res_dir, nii_file), os.path.join(res_dir, bids_fname))
+        shutil.move(os.path.join(res_dir, bids_fname), data_type_dir)
 
 
-def yaml_bids_filename(XNAT, data_type, scan_id, subj, sess, project, scan_file, xnat_mapping_type, sess_idx, subj_idx):
+def yaml_bids_filename(XNAT, data_type, scan_id, subj, sess, project, scan_file, xnat_mapping_type, sess_idx, subj_idx,
+                       series_description):
+    """
+    Main method to put the scans in the BIDS datatype folder, create json
+    sidecar and remane filenames based on the BIDS format.
+    :param XNAT: XNAT interface
+    :param data_type: BIDS datatype of scan
+    :param scan_id: Scan id
+    :param subj: XNAT Subject
+    :param sess: XNAT Session
+    :param project: XANT Project
+    :param scan_file: Scan file on XNAT
+    :param xnat_mapping_type:
+    :param sess_idx: Session count number
+    :param subj_idx: Subject count number
+    :param series_description: series_description of the scan
+    :return: BIDS filename
+    """
     if data_type == "anat":
         bids_fname = "sub-" + subj_idx + '_' + "ses-" + sess_idx + '_acq-' + scan_id + '_' + 'T1w' + \
                      '.' + ".".join(scan_file.split('.')[1:])
-
         return bids_fname
+
     elif data_type == "func":
+        # Get the task for the scan
         tk_dict = sd_tasktype_mapping(XNAT, project)
         task_type = tk_dict.get(xnat_mapping_type)
         if task_type == None:
             print(('ERROR: Scan type %s does not have a BIDS tasktype mapping at default and project level ' \
                   'Use BidsMapping tool. Func folder not created' % xnat_mapping_type))
-            # func_folder = os.path.join(bids_sess_path, data_type)
-            # os.rmdir(func_folder)
+            print("ERROR: BIDS Conversion not complete")
             sys.exit()
-
         bids_fname = "sub-" + subj_idx + '_' + "ses-" + sess_idx + '_task-' + task_type + '_acq-' + scan_id + '_run-01' \
                      + '_' + 'bold' + '.' + ".".join(scan_file.split('.')[1:])
         return bids_fname
+
     elif data_type == "dwi":
-        if label == "BVEC":
-            bids_fname = "sub-" + subj_idx + '_' + "ses-" + sess_idx + '_acq-' + scan_id + '_' + 'dwi' + '.' + 'bvec'
+        if scan_file.endswith('bvec.txt'):
+            bids_fname = "sub-" + subj_idx + '_' + "ses-" + sess_idx + '_acq-' + scan_id + '_run-' + scan_id + '_' + 'dwi' + '.' + 'bvec'
 
-        elif label == "BVAL":
-            bids_fname = "sub-" + subj_idx + '_' + "ses-" + sess_idx + '_acq-' + scan_id + '_' + 'dwi' + '.' + 'bval'
-
+        elif scan_file.endswith('bval.txt'):
+            bids_fname = "sub-" + subj_idx + '_' + "ses-" + sess_idx + '_acq-' + scan_id + '_run-' + scan_id + '_' + 'dwi' + '.' + 'bval'
         else:
-            bids_fname = "sub-" + subj_idx + '_' + "ses-" + sess_idx + '_acq-' + scan_id + '_' + 'dwi' + \
+            bids_fname = "sub-" + subj_idx + '_' + "ses-" + sess_idx + '_acq-' + scan_id + '_run-' + scan_id + '_' + 'dwi' + \
                          '.' + ".".join(scan_file.split('.')[1:])
         return bids_fname
 
@@ -169,41 +221,69 @@ def yaml_bids_filename(XNAT, data_type, scan_id, subj, sess, project, scan_file,
 
 def yaml_create_json(XNAT, data_type, res_dir, scan_file, uri, project, xnat_mapping_type, sess, is_json_present,
                      nii_file,
-                     json_file):
+                     json_file, series_description):
+    """
+    :param XNAT: XNAT interface
+    :param data_type: BIDS datatype of the scan
+    :param res_dir: XNAT Resource directory
+    :param scan_file: XNAT Scan file
+    :param uri: Link of scan file on XNAT
+    :param project: Project ID
+    :param xnat_mapping_type: Type of mapping used on XNAT (scan_type or series_description)
+    :param sess: Xnat sesssion
+    :param is_json_present: json sidecar present or absent in XNAT (boolean)
+    :param nii_file: Scan file ($col1 in yaml)
+    :param json_file: json sidecar filename
+    :param series_description: series description for scan file on XNAT
+    :return: xnat_prov - json that needs to be uploaded with nifti
+    """
+    # For dwi, fmap and anat - add only XNAT details to json sidecar
     if data_type != 'func':
         xnat_detail = {"XNATfilename": scan_file,
-                       "XNATProvenance": uri}
+                       "XNATProvenance": uri,
+                       "SeriesDescription": series_description}
         if not is_json_present:
             print('\t\t>No json sidecar. Created json sidecar with xnat info.')
             xnat_prov = xnat_detail
         else:
-            # print os.path.join(res_dir, json_file)
             with open(os.path.join(res_dir, json_file), "r+") as f:
                 print('\t\t>Json sidecar exists. Added xnat info.')
                 xnat_prov = json.load(f)
                 xnat_prov.update(xnat_detail)
-                # file.seek(0)
-                # json.dump(xnat_prov, f, indent=2)
-                # print xnat_prov
+
 
     else:
+        # For func check out details in nifti and json is required
         xnat_prov = yaml_func_json_sidecar(XNAT, data_type, res_dir, scan_file, uri, project, xnat_mapping_type,
                                            nii_file,
                                            is_json_present, sess, json_file)
-        # print xnat_prov
     return xnat_prov
 
 
 def yaml_func_json_sidecar(XNAT, data_type, res_dir, scan_file, uri, project, xnat_mapping_type, nii_file,
                            is_json_present,
                            sess, json_file):
+    """
+
+    :param XNAT: XNAT interface
+    :param data_type: BIDS datatype of the scan
+    :param res_dir: XNAT Resource directory
+    :param scan_file: XNAT Scan file
+    :param uri: Link of scan file on XNAT
+    :param project: Project ID
+    :param xnat_mapping_type:  Type of mapping used on XNAT (scan_type or series_description)
+    :param nii_file: Scan file ($col1 in yaml)
+    :param is_json_present: json sidecar present or absent in XNAT (boolean)
+    :param sess: XNAT Session ID
+    :param json_file: json sidecar filename
+    :return: json sidecare for func datatype
+    """
     xnat_prov = None
     tr_dict = sd_tr_mapping(XNAT, project)
     TR_bidsmap = tr_dict.get(xnat_mapping_type)
     if TR_bidsmap == None:
         print(('\t\t>ERROR: Scan type %s does not have a TR mapping' % xnat_mapping_type))
-        # func_folder = os.path.dirname(bids_res_path)
-        # os.rmdir(func_folder)
+        print("\t\t>ERROR: BIDS Conversion not complete")
         sys.exit()
     TR_bidsmap = round((float(TR_bidsmap)), 3)
     tk_dict = sd_tasktype_mapping(XNAT, project)
@@ -212,10 +292,14 @@ def yaml_func_json_sidecar(XNAT, data_type, res_dir, scan_file, uri, project, xn
     units = img.header.get_xyzt_units()[1]
     if units != 'sec':
         print("\t\t>ERROR: the units in nifti header is not secs")
+        print("\t\t>ERROR: BIDS Conversion not complete")
         func_folder = os.path.dirname(bids_res_path)
         os.rmdir(func_folder)
         sys.exit()
     TR_nifti = round((img.header['pixdim'][4]), 3)
+    # If json not present - if TR in nifti and XNAT (project level) is equal, USE TR FROM NIFTI
+    #                       if TR in nifti and XNAT (project level) is not equal, USE TR FROM XNAT (Project level) and
+    #                                                                             UPDATE THE NIFTI HEADER
     if not is_json_present:
         xnat_prov = {"XNATfilename": scan_file,
                      "XNATProvenance": uri,
@@ -224,15 +308,18 @@ def yaml_func_json_sidecar(XNAT, data_type, res_dir, scan_file, uri, project, xn
             print((
                 '\t\t>No existing json. TR %.3f sec in BIDS mapping and NIFTI header. Using TR %.3f sec in nifti header ' \
                 'for scan file %s in session %s. ' % (TR_bidsmap, TR_bidsmap, scan_file, sess)))
-            xnat_prov["RepetitionTime"] = TR_nifti
+            xnat_prov["RepetitionTime"] = float(TR_nifti)
         else:
             print((
                 '\t\t>No existing json. WARNING: The TR is %.3f sec in project level BIDS mapping, which does not match the TR of %.3f sec in NIFTI header.\n  ' \
                 '\t\tUPDATING NIFTI HEADER to match BIDS mapping TR %.3f sec for scan file %s in session %s.' \
                 % (TR_bidsmap, TR_nifti, TR_bidsmap, scan_file, sess)))
-            xnat_prov["RepetitionTime"] = TR_bidsmap
+            xnat_prov["RepetitionTime"] = float(TR_bidsmap)
             img.header['pixdim'][4] = TR_bidsmap
             nib.save(img, os.path.join(res_dir, nii_file))
+    # If json present - if TR in JSON and XNAT (project level) is equal,     USE THE SAME JSON
+    #                 - if TR in JSON and XNAT (project level) is not equal, USE TR FROM XNAT (Project level) and
+    #                                                                         UPDATE THE NIFTI HEADER
     else:
         with open(os.path.join(res_dir, json_file), "r+") as f:
             xnat_prov = json.load(f)
@@ -245,7 +332,7 @@ def yaml_func_json_sidecar(XNAT, data_type, res_dir, scan_file, uri, project, xn
                     '\t\t>JSON sidecar exists. WARNING: TR is %.3f sec in project level BIDS mapping, which does not match the TR in JSON sidecar %.3f.\n ' \
                     '\t\tUPDATING JSON with TR %.3f sec in BIDS mapping and UPDATING NIFTI header for scan %s in session %s.' \
                     % (TR_bidsmap, TR_json, TR_bidsmap, scan_file, sess)))
-                xnat_detail['RepetitionTime'] = TR_bidsmap
+                xnat_detail['RepetitionTime'] = float(TR_bidsmap)
                 xnat_prov.update(xnat_detail)
                 img.header['pixdim'][4] = TR_bidsmap
                 nib.save(img, os.path.join(res_dir, nii_file))
@@ -259,6 +346,12 @@ def yaml_func_json_sidecar(XNAT, data_type, res_dir, scan_file, uri, project, xn
 
 
 def sd_tr_mapping(XNAT, project):
+    """
+    Method to get the Repetition Time mapping from Project level
+    :param XNAT: XNAT interface
+    :param project: XNAT Project ID
+    :return: Dictonary with scan_type/series_description and  Repetition Time mapping
+    """
     tr_dict = {}
     if XNAT.select('/data/projects/' + project + '/resources/BIDS_repetition_time_sec').exists():
         for res in XNAT.select('/data/projects/' + project + '/resources/BIDS_repetition_time_sec/files').get():
@@ -269,27 +362,23 @@ def sd_tr_mapping(XNAT, project):
                     tr_mapping = json.load(f)
                     print(('\t\t>Using BIDS Repetition Time in secs mapping in project level %s' % (project)))
                     tr_dict = tr_mapping[project]
-                    # tr_dict = {k.strip().replace('/', '_').replace(" ", "").replace(":", '_')
-                    #: v for k, v in tr_dict.items()}
+
     else:
         print("\t\t>ERROR: no TR mapping at project level. Func folder not created")
-        # func_folder = os.path.dirname(bids_res_path)
-        # os.rmdir(func_folder)
+        print("\t\t>ERROR: BIDS Conversion not complete")
         sys.exit()
     return tr_dict
 
 
 def sd_datatype_mapping(XNAT, project):
     """
-      Method to map scan type to task type for functional scans
-
-      :return: mapping dict
+    Method to get the Datatype mapping from Project level
+    :param XNAT: XNAT interface
+    :param project: XNAT Project ID
+    :return: Dictonary with scan_type/series_description and datatype mapping
     """
     sd_dict = {}
-    # if OPTIONS.selectionScan:
-    # project = OPTIONS.selectionScan.split('-')[0]
-    # else:
-    # project = OPTIONS.project
+
     if XNAT.select('/data/projects/' + project + '/resources/BIDS_datatype').exists():
         for res in XNAT.select('/data/projects/' + project + '/resources/BIDS_datatype/files').get():
             if res.endswith('.json'):
@@ -298,11 +387,9 @@ def sd_datatype_mapping(XNAT, project):
                     datatype_mapping = json.load(f)
                     sd_dict = datatype_mapping[project]
                     print(('\t\t>Using BIDS datatype mapping in project level %s' % (project)))
-                    # sd_dict = {k.strip().replace('/', '_').replace(" ", "").replace(":", '_')
-                    #: v for k, v in sd_dict.items()}
+
     else:
         print(('\t\t>WARNING: No BIDS datatype mapping in project %s - using default mapping' % (project)))
-        # LOGGER.info('WARNING: No BIDS datatype mapping in project %s - using default mapping' % (project))
         scans_list_global = XNAT.get_project_scans('LANDMAN')
 
         for sd in scans_list_global:
@@ -336,22 +423,19 @@ def sd_datatype_mapping(XNAT, project):
 
 def sd_tasktype_mapping(XNAT, project):
     """
-     Method to map scan type to task type for functional scans
-
-     :return: mapping dict
-     """
+    Method to get the Task type mapping at Project level
+    :param XNAT: XNAT interface
+    :param project: XNAT Project ID
+    :return: Dictonary with scan_type/series_description and tasktype mapping
+    """
     tk_dict = {}
-    # project = OPTIONS.project
     if XNAT.select('/data/projects/' + project + '/resources/BIDS_tasktype').exists():
         for res in XNAT.select('/data/projects/' + project + '/resources/BIDS_tasktype/files').get():
             if res.endswith('.json'):
                 with open(XNAT.select('/data/projects/' + project + '/resources/BIDS_tasktype/files/'
                                       + res).get(), "r+") as f:
                     datatype_mapping = json.load(f)
-                    # print "\t\t>Using tasktype mapping in project level %s" % (project)
                     tk_dict = datatype_mapping[project]
-                    # tk_dict = {k.strip().replace('/', '_').replace(" ", "").replace(":", '_')
-                    #: v for k, v in tk_dict.items()}
 
     else:
         print(('\t\t>WARNING: No BIDS task type mapping in project %s - using default mapping' % (project)))
@@ -369,10 +453,10 @@ def sd_tasktype_mapping(XNAT, project):
 def dataset_description_file(BIDS_DIR, XNAT, project):
     """
     Build BIDS dataset description json file
-
-    :return: None
+    :param BIDS_DIR: BIDS directory
+    :param XNAT: XNAT interface
+    :param project: XNAT Project
     """
-
     BIDSVERSION = "1.0.1"
     dataset_description = dict()
     dataset_description['BIDSVersion'] = BIDSVERSION
@@ -390,8 +474,3 @@ def dataset_description_file(BIDS_DIR, XNAT, project):
         os.makedirs(dd_file)
     with open(os.path.join(dd_file, 'dataset_description.json'), 'w+') as f:
         json.dump(dataset_description, f, indent=2)
-
-
-
-
-


### PR DESCRIPTION
Added the option --bids --bids_dir to Xnatdownload tool. It transfers the data from XNAT hierarchy to a BIDS folder. It works for downloading BIDS compliant sessions. The tool renames files and adds json sidecar (if it is not present). These sessions can be used as inputs to BIDS app. 
(Eg: Xnatdownload -d one_sess/ --p WOODWARD_TCP --sess 113499 -s T1W/3D/TFE,Resting" "State --rs NIFTI --bids --bids_dir bids_dataset/)
BIDSMapping tool is used to create/modify the BIDS datatype, tasktype and repetition time mapping to the series description or scan type of the scans on XNAT. These mapping/rules are present at the project level on XNAT. BIDSMapping --help for detailed information.