### PR TITLE
nibabel req for BIDS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyxnat
 pyyaml
 pycap
+nibabel

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,8 @@ REQUIRES = [
     'pyxnat>=%s' % PYXNAT_MIN_VERSION,
     'pyyaml',
     'pycap',
-    'configparser'
+    'configparser',
+    'nibabel'
 ]
 
 TESTS_REQUIRES = ['nose']


### PR DESCRIPTION
Is the extra line in requirements.txt all we need to handle the nibabel dependency? There is no good alternative in my opinion for this dependency if we want BIDS.