### PR TITLE
Add support for pet scans inputs

### DIFF
--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -728,8 +728,18 @@ in session %s'
         for auto_proc in auto_proc_list:
             # return a mapping between the assessor input sets and existing
             # assessors that map to those input sets
-            auto_proc.parse_session(csess, sessions)
-            mapping = auto_proc.get_assessor_mapping()
+
+            # BDB 6/5/21
+            # For now, we will not process pet sessions here, but will
+            # include them as additional params for mr sessions.
+            if csess.datatype() == 'xnat:petSessionData':
+                LOGGER.debug('pet session, skipping auto processors')
+                continue
+            else:
+                pets = [x for x in sessions if x.datatype() == 'xnat:petSessionData']
+                mrs = [x for x in sessions if x.datatype() != 'xnat:petSessionData']
+
+            mapping = auto_proc.parse_session(csess, mrs, pets)
 
             if mapping is None:
                 continue
@@ -746,6 +756,7 @@ in session %s'
                 else:
                     assessors = []
                     for p in p_assrs:
+                        # BDB 6/5/21 is there ever more than one assessor here?
                         info = p.info()
                         procstatus = info['procstatus']
                         qcstatus = info['qcstatus']

--- a/dax/processors.py
+++ b/dax/processors.py
@@ -422,10 +422,7 @@ class AutoProcessor(Processor):
             err = 'YAML source {} does not have {} defined. See example.'
             raise AutoProcessorError(err.format(source_id, key))
 
-    def get_assessor_mapping(self):
-        return self.parser.assessor_parameter_map
-
-    def parse_session(self, csess, sessions):
+    def parse_session(self, csess, sessions, pets=None):
         """
         Method to run the processor parser on this session, in order to
         calculate the pattern matches for this processor and the sessions
@@ -438,7 +435,7 @@ class AutoProcessor(Processor):
         considered for longitudinal studies.
         :return: None
         """
-        self.parser.parse_session(csess, sessions)
+        return self.parser.parse_session(csess, sessions, pets)
 
     def get_proctype(self):
         return self.name
@@ -492,7 +489,7 @@ class AutoProcessor(Processor):
         # TODO: BenM/assessor_of_assessor/each assessor is separate and
         # has a different label; change the code to fetch the label from
         # the assessor
-        # Add assr and jobidr:
+        # Add assr and jobdir:
         assr_full_name =\
             assessor_utils.full_label_from_assessor(assr)
         if ' -a ' not in cmd and ' --assessor ' not in cmd:


### PR DESCRIPTION
This adds support for a new section in the processor yaml for PET scans. An example is here:
https://github.com/VUIIS/yaml_processors/blob/petscans/AMYVIDQA_v1.1.0_processor.yaml

Any and all PET sessions will be linked in with the first MR session. The pet session will be matched by the tracer name. Then the scan type will be matched.

Also, I tried to leave a trail of notes about how the affected code works because it is rather opaque.
