### PR TITLE
processor v3 minor fixes

### DIFF
--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -34,7 +34,8 @@ from . import utilities
 # The prefix can be any word characters plus the dash character.
 # The suffix must be an underscore followed by the letter v and then the
 # semantic versioning version X.Y.Z and finally it must end with .yaml
-YAML_PATTERN = '^[\w-]*_v[\d]*\.[\d]*\.[\d]*\.yaml$'
+# 2/1/22 now using the official semver matching expression
+YAML_PATTERN = '^[\w-]*_v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?.yaml$'
 
 # Logger for logs
 LOGGER = logging.getLogger('dax')
@@ -1223,7 +1224,8 @@ def parse_artefacts(csess, pets=[]):
 
     return artefacts
 
-
+# Returns the full URI for the resource_path as a child of input path which
+# can be either a scan or an assessor
 def get_uri(host, input_path, resource_path):
     if '/scans/' in input_path:
         uri_path = '{0}/data{1}/resources/{2}'.format(host, input_path, resource_path)
@@ -1234,7 +1236,8 @@ def get_uri(host, input_path, resource_path):
 
     return uri_path
 
-
+# Returns an xnat object for the resource that is a child of input_path 
+# which can be either a scan or an assessor
 def get_resource(xnat, input_path, resource):
     if '/scans/' in input_path:
         resource_path = '{0}/resources/{1}'
@@ -1246,14 +1249,16 @@ def get_resource(xnat, input_path, resource):
 
     return robj
 
-
+# Returns the processing type (proctype) as parsed from the aleady validated
+# yaml file name
 def parse_proctype(yaml_file):
     # At this point we assume the yaml file name is valid
     tmp = os.path.basename(yaml_file)
     tmp = tmp.rsplit('.')[-4]
     return tmp
 
-
+# Returns the processing version (procversion) as parsed from the aleady validated
+# yaml file name
 def parse_procversion(yaml_file):
     # At this point we assume the yaml file name is valid
     tmp = os.path.basename(yaml_file)


### PR DESCRIPTION
-make fdest optional in inputs, use the original file or resource name when not fdest is not set
-use semver official pattern for matching processor v3 yaml file names
-use the first file when multiple are found for an input