### PR TITLE
Handle multiple files found using fmulti

### DIFF
--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -834,12 +834,12 @@ class Processor_v3(object):
 
                     if len(file_list) > 1:
                         # Multiple files found, we only support explicit
-                        # declaration of fmulti==any, which tells dax to use
+                        # declaration of fmulti==any1, which tells dax to use
                         # any of the multiple files. We may later support
                         # other options
 
-                        if 'fmulti' in cur_res and cur_res['fmulti'] == 'any':
-                            LOGGER.debug('multiple files, fmulti==any, using first found')
+                        if 'fmulti' in cur_res and cur_res['fmulti'] == 'any1':
+                            LOGGER.debug('multiple files, fmulti==any1, using first found')
                         else:
                             LOGGER.debug('multiple files, fmulti not set')
                             raise NeedInputsException(artk + ': multiple files')

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -833,11 +833,16 @@ class Processor_v3(object):
                         raise NeedInputsException('No Files')
 
                     if len(file_list) > 1:
-                        # TODO: decide how we want to handle multiple files
-                        # Make a comma separated list of files
-                        #uri_list = ['{}/files/{}'.format(resource, f) for f in file_list]
-                        #res_path = ','.join(uri_list)
-                        LOGGER.debug('multiple files, using first only')
+                        # Multiple files found, we only support explicit
+                        # declaration of fmulti==any, which tells dax to use
+                        # any of the multiple files. We may later support
+                        # other options
+
+                        if 'fmulti' in cur_res and cur_res['fmulti'] == 'any':
+                            LOGGER.debug('multiple files, fmulti==any, using first found')
+                        else:
+                            LOGGER.debug('multiple files, fmulti not set')
+                            raise NeedInputsException(artk + ': multiple files')
 
                     # Create the full path to the file on the resource
                     res_path = '{}/files/{}'.format(resource, file_list[0])


### PR DESCRIPTION
This implements the processor v3 option "fmulti: any". This key/value can be included with any FILE resource. dax will then use any file when multiple files are found. In the case where multiple files are found and this key/value is not set, dax will set the assessor status to Need Inputs with a qc status of "multiple files". 