### PR TITLE
Handle multiple scans with same type; allow not building for unusable scans

### DIFF
--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1040,7 +1040,7 @@ class Processor_v3(object):
                     if not tracer_match:
                         # None of the expressions matched
                         LOGGER.debug(
-                            'tracer no matchy:{}:{}'.format(tracer_name, iv['tracer'])
+                            'tracer not matched:{}:{}'.format(tracer_name, iv['tracer'])
                         )
                         continue
 

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1082,24 +1082,17 @@ class Processor_v3(object):
                                     # vs a different requested type
                                     artefacts_by_input[i].append(cscan.full_path())
                                     artefact_ids_by_input[i].append(cscan.info().get('ID'))
-                                    artefact_types_by_input[i].append(cscan.type())
                                     break
                                     
-                    # If requested, check for multiple same-named scans in the list and only keep
+                    # If requested, check for multiple matching scans in the list and only keep
                     # the first. Sort lowercase by alpha, on scan ID.
                     if iv['keep_multis'] == 'first':
                         scan_info = zip(
                             artefacts_by_input[i],
                             artefact_ids_by_input[i],
-                            artefact_types_by_input[i],
                             )
                         sorted_info = sorted(scan_info, key=lambda x: str(x[1]).lower())
-                        seen_types = []
-                        for inf in sorted_info:
-                            if inf[2] in seen_types:
-                                artefacts_by_input[i].remove(inf[0])
-                            else:
-                                seen_types.append(inf[2])
+                        artefacts_by_input[i] = sorted_info[0][0]
                                 
                     elif iv['keep_multis'] != 'all':
                         msg = 'keep_multis must be "first" or "all"'

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1053,22 +1053,23 @@ class Processor_v3(object):
                                     artefacts_by_input[i].append(pscan.full_path())
 
             else:
-                # Iterate each scan on the session
-                for cscan in csess.scans():
-                    for expression in iv['types']:
-                        regex = utilities.extract_exp(expression)
-                        if regex.match(cscan.type()):
-                            artefacts_by_input[i].append(cscan.full_path())
-                            # Break here so we don't match multiple times
-                            break
-
-                for cassr in csess.assessors():
-                    try:
-                        if cassr.type() in iv['types']:
-                            artefacts_by_input[i].append(cassr.full_path())
-                    except:
-                        # Perhaps type/proctype is missing
-                        LOGGER.error(f'Failed to add {cassr.label()} to processing list')
+                # Iterate each scan or assessor on the session
+                if iv['artefact_type'] == 'scan':
+                    for cscan in csess.scans():
+                        for expression in iv['types']:
+                            regex = utilities.extract_exp(expression)
+                            if regex.match(cscan.type()):
+                                artefacts_by_input[i].append(cscan.full_path())
+                                # Break here so we don't match multiple times for same scan
+                                break
+                elif iv['artefact_type'] == 'assessor':
+                    for cassr in csess.assessors():
+                        try:
+                            if cassr.type() in iv['types']:
+                                artefacts_by_input[i].append(cassr.full_path())
+                        except:
+                            # Perhaps type/proctype is missing
+                            LOGGER.warning(f'Unable to check match of {cassr.label()} - ignoring')
                         
         return artefacts_by_input
 
@@ -1149,7 +1150,7 @@ class Processor_v3(object):
             try:
                 proc_type_matches = (casr.type() == proc_type)
             except:
-                LOGGER.error(f'Failed to check type of {casr.label()}')
+                LOGGER.warning(f'Unable to check match of {casr.label()} - ignoring')
                 continue
             
             if proc_type_matches:

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1083,7 +1083,7 @@ class Processor_v3(object):
                             artefact_ids_by_input[i],
                             artefact_types_by_input[i],
                             )
-                        sorted_info = sorted(scan_info.items(), key=lambda x: lower(str(x[1])))
+                        sorted_info = sorted(scan_info, key=lambda x: lower(str(x[1])))
                         seen_types = []
                         for inf in sorted_info:
                             if inf[2] in seen_types:

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -709,7 +709,7 @@ class Processor_v3(object):
         #
         # Really insidious error case here: if an element of artefacts_by_input
         # is not a list, the build will "leak" past what has been requested and
-        # start building every project.
+        # start building every project. This is now checked in _map_artefacts_to_inputs
 
         parameter_matrix = self._generate_parameter_matrix(
             artefacts, artefacts_by_input
@@ -1114,7 +1114,8 @@ class Processor_v3(object):
                             LOGGER.warning(f'Unable to check match of {cassr.label()} - ignoring')
         
         # Validate - each value of artefacts_by_input must be a list
-        for k, v in artefacts_by_input:
+        print(f'TYPE IS {type(artefacts_by_input)}')
+        for abi in artefacts_by_input:
             if not isinstance(v, list):
                 msg = f'Non-list found in artefacts_by_input field {k}: {v}'
                 LOGGER.error(msg)

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1092,7 +1092,7 @@ class Processor_v3(object):
                             artefact_ids_by_input[i],
                             )
                         sorted_info = sorted(scan_info, key=lambda x: str(x[1]).lower())
-                        artefacts_by_input[i] = list(sorted_info)[0][0]
+                        artefacts_by_input[i] = [sorted_info[0][0]]
                                 
                     elif iv['keep_multis'] != 'all':
                         msg = 'keep_multis must be "first" or "all"'

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1020,6 +1020,8 @@ class Processor_v3(object):
         # the pet scans I think? are we treating assessors scans differently
         # here or not?
         artefacts_by_input = {k: [] for k in inputs}
+        artefact_ids_by_input = {k: [] for k in inputs}
+        artefact_types_by_input = {k: [] for k in inputs}
 
         for i, iv in list(inputs.items()):
             # BDB 6/5/21
@@ -1071,17 +1073,16 @@ class Processor_v3(object):
                                     LOGGER.info(f'Excluding unusable scan {cscan.label()}')
                                 else:
                                     artefacts_by_input[i].append(cscan.full_path())
+                                    artefact_ids_by_input[i].append(cscan.info().get('ID'))
+                                    artefact_types_by_input[i].append(cscan.type())
                                     break  # don't match multiple times for same scan
                     # Check for multiple same-named scans in the list. Sort lowercase by alpha
                     if iv['keep_multis'] == 'first':
-                        scan_paths = []
-                        scan_ids = []
-                        scan_types = []
-                        for scan_path in artefacts_by_input[i]:
-                            scan_paths.append(scan_path)
-                            scan_ids.append(artefacts[scan_path].entity.info['ID'])
-                            scan_types.append(artefacts[scan_path].entity.info['type'])
-                        scan_info = zip(scan_paths, scan_ids, scan_types)
+                        scan_info = zip(
+                            artefacts_by_input[i],
+                            artefact_ids_by_input[i],
+                            artefact_types_by_input[i],
+                            )
                         sorted_info = sorted(scan_info.items(), key=lambda x: lower(str(x[1])))
                         seen_types = []
                         for inf in sorted_info:

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1099,7 +1099,7 @@ class Processor_v3(object):
                         artefacts_by_input[i] = [sorted_info[0][0]]
                         LOGGER.info(
                             f'Keeping only the first scan found for '
-                            f'{iv["name"]}: {sorted_info[0][0]}'
+                            f'{i}: {sorted_info[0][0]}'
                             )
 
                     elif iv['keep_multis'] != 'all':

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -935,7 +935,11 @@ class Processor_v3(object):
 
             needs_qc = s.get('needs_qc', False)
 
+            # Consider an MR scan for an input if it's marked Unusable?
             skip_unusable = s.get('skip_unusable', False)
+
+            # Include the 'first', or 'all', matching scans as possible inputs
+            keep_multis = s.get('keep_multis', 'all')
 
             self.proc_inputs[name] = {
                 'types': types,
@@ -944,6 +948,7 @@ class Processor_v3(object):
                 'resources': resources,
                 'required': artefact_required,
                 'skip_unusable': skip_unusable,
+                'keep_multis': keep_multis,
             }
 
         # get assessors
@@ -1067,6 +1072,15 @@ class Processor_v3(object):
                                 else:
                                     artefacts_by_input[i].append(cscan.full_path())
                                     break  # don't match multiple times for same scan
+                    # BPR TODO Check here for multiple same-named scans in the list
+                    if iv['keep_multis'] == 'first':
+                        msg = 'keep_multis "first" not yet implemented'
+                        LOGGER.error(msg)
+                        raise AutoProcessorError(msg)
+                    elif iv['keep_multis'] != 'all':
+                        msg = 'keep_multis must be "first" or "all"'
+                        LOGGER.error(msg)
+                        raise AutoProcessorError(msg)
 
                 elif iv['artefact_type'] == 'assessor':
                     for cassr in csess.assessors():

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1092,7 +1092,7 @@ class Processor_v3(object):
                             artefact_ids_by_input[i],
                             )
                         sorted_info = sorted(scan_info, key=lambda x: str(x[1]).lower())
-                        artefacts_by_input[i] = sorted_info[0][0]
+                        artefacts_by_input[i] = list(sorted_info)[0][0]
                                 
                     elif iv['keep_multis'] != 'all':
                         msg = 'keep_multis must be "first" or "all"'

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1083,7 +1083,7 @@ class Processor_v3(object):
                             artefact_ids_by_input[i],
                             artefact_types_by_input[i],
                             )
-                        sorted_info = sorted(scan_info, key=lambda x: lower(str(x[1])))
+                        sorted_info = sorted(scan_info, key=lambda x: str(x[1]).lower())
                         seen_types = []
                         for inf in sorted_info:
                             if inf[2] in seen_types:

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1022,7 +1022,6 @@ class Processor_v3(object):
 
     def _map_artefacts_to_inputs(self, csess, pets):
         inputs = self.proc_inputs
-        print(inputs)
 
         # BDB 6/5/21
         # here is where we should do something different for
@@ -1076,6 +1075,7 @@ class Processor_v3(object):
                 if iv['artefact_type'] == 'scan':
                     for cscan in csess.scans():
                         for expression in iv['types']:
+                            print(f'Looking for {i} in scans')
                             regex = utilities.extract_exp(expression)
                             if regex.match(cscan.type()):
                                 if iv['skip_unusable'] and cscan.info().get('quality') == 'unusable':
@@ -1084,6 +1084,7 @@ class Processor_v3(object):
                                     # Get scan path, scan ID for each matching scan.
                                     # Break if the scan matches so we don't find it again comparing
                                     # vs a different requested type
+                                    print(f'Match for {i}: {cscan.full_path()}')
                                     artefacts_by_input[i].append(cscan.full_path())
                                     artefact_ids_by_input[i].append(cscan.info().get('ID'))
                                     break
@@ -1109,9 +1110,11 @@ class Processor_v3(object):
 
                 # Find matching assessors in the session, if asked for an assessor
                 elif iv['artefact_type'] == 'assessor':
+                    print(f'Looking for {i} in assessors')
                     for cassr in csess.assessors():
                         try:
                             if cassr.type() in iv['types']:
+                                print(f'Match for {i}: {cassr.full_path()}')
                                 artefacts_by_input[i].append(cassr.full_path())
                         except:
                             # Perhaps type/proctype is missing

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1114,8 +1114,7 @@ class Processor_v3(object):
                             LOGGER.warning(f'Unable to check match of {cassr.label()} - ignoring')
         
         # Validate - each value of artefacts_by_input must be a list
-        print(f'TYPE IS {type(artefacts_by_input)}')
-        for abi in artefacts_by_input:
+        for k, v in artefacts_by_input.items():
             if not isinstance(v, list):
                 msg = f'Non-list found in artefacts_by_input field {k}: {v}'
                 LOGGER.error(msg)

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1081,7 +1081,7 @@ class Processor_v3(object):
                                 if iv['skip_unusable'] and cscan.info().get('quality') == 'unusable':
                                     LOGGER.info(f'Excluding unusable scan {cscan.label()}')
                                 else:
-                                    # Get scan path, scan ID, and scan type for each matching scan.
+                                    # Get scan path, scan ID for each matching scan.
                                     # Break if the scan matches so we don't find it again comparing
                                     # vs a different requested type
                                     artefacts_by_input[i].append(cscan.full_path())

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1072,11 +1072,23 @@ class Processor_v3(object):
                                 else:
                                     artefacts_by_input[i].append(cscan.full_path())
                                     break  # don't match multiple times for same scan
-                    # BPR TODO Check here for multiple same-named scans in the list
+                    # Check for multiple same-named scans in the list. Sort lowercase by alpha
                     if iv['keep_multis'] == 'first':
-                        msg = 'keep_multis "first" not yet implemented'
-                        LOGGER.error(msg)
-                        raise AutoProcessorError(msg)
+                        scan_paths = []
+                        scan_ids = []
+                        scan_types = []
+                        for scan_path in artefacts_by_input[i]:
+                            scan_paths.append(scan_path)
+                            scan_ids.append(artefacts[scan_path].entity.info['ID'])
+                            scan_types.append(artefacts[scan_path].entity.info['type'])
+                        scan_info = zip(scan_paths, scan_ids, scan_types)
+                        sorted_info = sorted(scan_info.items(), key=lambda x: lower(str(x[1])))
+                        seen_types = []
+                        for inf in sorted_info:
+                            if inf[2] in seen_types:
+                                artefacts_by_input[i].remove(inf[0])
+                            else:
+                                seen_types.append(inf[2])
                     elif iv['keep_multis'] != 'all':
                         msg = 'keep_multis must be "first" or "all"'
                         LOGGER.error(msg)

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1029,7 +1029,6 @@ class Processor_v3(object):
         # here or not?
         artefacts_by_input = {k: [] for k in inputs}
         artefact_ids_by_input = {k: [] for k in inputs}
-        artefact_types_by_input = {k: [] for k in inputs}
 
         for i, iv in list(inputs.items()):
             # BDB 6/5/21

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1104,11 +1104,11 @@ class Processor_v3(object):
                             try:
                                 idx_multi = int(iv['keep_multis'])
                             except:
-                                msg = f'keep_multis must be first, last, or index 1,2,3,...'
+                                msg = f'For {i}, keep_multis must be first, last, or index 1,2,3,...'
                                 LOGGER.error(msg)
                                 raise AutoProcessorError(msg)
                             if idx_multi > num_scans:
-                                msg = f'Requested {idx_multi}th scan, but only {num_scans} found'
+                                msg = f'Requested {idx_multi}th scan for {i}, but only {num_scans} found'
                                 LOGGER.error(msg)
                                 raise AutoProcessorError(msg)
                         artefacts_by_input[i] = [sorted_info[idx_multi-1][0]]

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1099,7 +1099,7 @@ class Processor_v3(object):
                         artefacts_by_input[i] = [sorted_info[0][0]]
                         LOGGER.info(
                             f'Keeping only the first scan found for '
-                            '{iv["name"]}: {sorted_info[0][0]}'
+                            f'{iv["name"]}: {sorted_info[0][0]}'
                             )
 
                     elif iv['keep_multis'] != 'all':

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1097,7 +1097,11 @@ class Processor_v3(object):
                             )
                         sorted_info = sorted(scan_info, key=lambda x: str(x[1]).lower())
                         artefacts_by_input[i] = [sorted_info[0][0]]
-                                
+                        LOGGER.info(
+                            f'Keeping only the first scan found for '
+                            '{iv["name"]}: {sorted_info[0][0]}'
+                            )
+
                     elif iv['keep_multis'] != 'all':
                         msg = 'keep_multis must be "first" or "all"'
                         LOGGER.error(msg)

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1096,7 +1096,7 @@ class Processor_v3(object):
                             artefact_ids_by_input[i],
                             )
                         sorted_info = sorted(scan_info, key=lambda x: str(x[1]).lower())
-                        artefacts_by_input[i] = sorted_info[0][0]
+                        artefacts_by_input[i] = [sorted_info[0][0]]
                                 
                     elif iv['keep_multis'] != 'all':
                         msg = 'keep_multis must be "first" or "all"'

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1072,6 +1072,7 @@ class Processor_v3(object):
             else:
                 
                 # Find matching scans in the session, if asked for a scan
+                print(iv['artefact_type'])
                 if iv['artefact_type'] == 'scan':
                     for cscan in csess.scans():
                         for expression in iv['types']:

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1022,6 +1022,7 @@ class Processor_v3(object):
 
     def _map_artefacts_to_inputs(self, csess, pets):
         inputs = self.proc_inputs
+        print(inputs)
 
         # BDB 6/5/21
         # here is where we should do something different for
@@ -1072,7 +1073,6 @@ class Processor_v3(object):
             else:
                 
                 # Find matching scans in the session, if asked for a scan
-                print(iv['artefact_type'])
                 if iv['artefact_type'] == 'scan':
                     for cscan in csess.scans():
                         for expression in iv['types']:

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -1075,7 +1075,6 @@ class Processor_v3(object):
                 if iv['artefact_type'] == 'scan':
                     for cscan in csess.scans():
                         for expression in iv['types']:
-                            print(f'Looking for {i} in scans')
                             regex = utilities.extract_exp(expression)
                             if regex.match(cscan.type()):
                                 if iv['skip_unusable'] and cscan.info().get('quality') == 'unusable':
@@ -1084,7 +1083,6 @@ class Processor_v3(object):
                                     # Get scan path, scan ID for each matching scan.
                                     # Break if the scan matches so we don't find it again comparing
                                     # vs a different requested type
-                                    print(f'Match for {i}: {cscan.full_path()}')
                                     artefacts_by_input[i].append(cscan.full_path())
                                     artefact_ids_by_input[i].append(cscan.info().get('ID'))
                                     break
@@ -1110,11 +1108,9 @@ class Processor_v3(object):
 
                 # Find matching assessors in the session, if asked for an assessor
                 elif iv['artefact_type'] == 'assessor':
-                    print(f'Looking for {i} in assessors')
                     for cassr in csess.assessors():
                         try:
                             if cassr.type() in iv['types']:
-                                print(f'Match for {i}: {cassr.full_path()}')
                                 artefacts_by_input[i].append(cassr.full_path())
                         except:
                             # Perhaps type/proctype is missing

--- a/docs/processors.rst
+++ b/docs/processors.rst
@@ -117,11 +117,7 @@ The **resources** subsection of each xnat scan should contain a list of resource
 
 The **var** field defines the tag to be replaced in the **command** string template (see below).
 
-Optional fields for a resource are **fmatch** and **fcount**. **fmatch** defines a regular expression to apply to filter the list of filenames in the resource. **fcount** can be used to limit the number of files matched. By default, only 1 file is downloaded.
-
-The optional **skip_unusable** field may be *False* (the default); or *True* to prevent building assessors that would have as an input a scan that is marked *unusable*. This is available for **scans**, but not **petscans** or **assessors**.
-
-The optional **keep_multis** field may be *all* (the default); or *first*. This applies when there are multiple scans in the session that match as possible inputs. Normally all matching scans are used as inputs, multiplying assessors as needed. When *first* is specified, only the first matching scan will be used as an input, reducing the number of assessors built by a factor of the number of matching scans. "First" is defined as alphabetical order by scan ID, cast to lowercase. The exact scan type is not considered; only whether there is a match with the **types** specified. This is available for **scans**, but not **petscans** or **assessors**.
+The optional **fmatch** field defines a regular expression to apply to filter the list of filenames in the resource.
 
 
 xnat assessors

--- a/docs/processors.rst
+++ b/docs/processors.rst
@@ -121,7 +121,7 @@ Optional fields for a resource are **fmatch** and **fcount**. **fmatch** defines
 
 The optional **skip_unusable** field may be *False* (the default); or *True* to prevent building assessors that would have as an input a scan that is marked *unusable*. This is available for **scans**, but not **petscans** or **assessors**.
 
-The optional **keep_multis** field may be *all* (the default); or *first*. This applies when there are multiple scans in the session that match as possible inputs. Normally one assessor is built for each matching scan. When *first* is specified, only one assessor will be built, using the first matching scan as its input. "First" is defined as alphabetical order by scan ID, cast to lowercase. The exact scan type is not considered; only whether there is a match with the **types** specified. This also is available for **scans**, but not **petscans** or **assessors**.
+The optional **keep_multis** field may be *all* (the default); or *first*. This applies when there are multiple scans in the session that match as possible inputs. Normally all matching scans are used as inputs, multiplying assessors as needed. When *first* is specified, only the first matching scan will be used as an input, reducing the number of assessors built by a factor of the number of matching scans. "First" is defined as alphabetical order by scan ID, cast to lowercase. The exact scan type is not considered; only whether there is a match with the **types** specified. This also is available for **scans**, but not **petscans** or **assessors**.
 
 
 xnat assessors

--- a/docs/processors.rst
+++ b/docs/processors.rst
@@ -119,6 +119,10 @@ The **var** field defines the tag to be replaced in the **command** string templ
 
 Optional fields for a resource are **fmatch** and **fcount**. **fmatch** defines a regular expression to apply to filter the list of filenames in the resource. **fcount** can be used to limit the number of files matched. By default, only 1 file is downloaded.
 
+The optional **skip_unusable** field may be *False* (the default); or *True* to prevent building assessors that would have as an input a scan that is marked *unusable*. This is available for **scans**, but not **petscans** or **assessors**.
+
+The optional **keep_multis** field may be *all* (the default); or *first*. This applies when there are multiple scans with the same type in the session, therefore multiple possible inputs for this scan. Normally one assessor is built for each matching scan. When *first* is specified, only one assessor will be built, using the first scan as its input. "First" is defined as alphabetical order by scan ID, cast to lowercase. This also is available for **scans**, but not **petscans** or **assessors**.
+
 
 xnat assessors
 ---------------

--- a/docs/processors.rst
+++ b/docs/processors.rst
@@ -121,7 +121,7 @@ Optional fields for a resource are **fmatch** and **fcount**. **fmatch** defines
 
 The optional **skip_unusable** field may be *False* (the default); or *True* to prevent building assessors that would have as an input a scan that is marked *unusable*. This is available for **scans**, but not **petscans** or **assessors**.
 
-The optional **keep_multis** field may be *all* (the default); or *first*. This applies when there are multiple scans with the same type in the session, therefore multiple possible inputs for this scan. Normally one assessor is built for each matching scan. When *first* is specified, only one assessor will be built, using the first scan as its input. "First" is defined as alphabetical order by scan ID, cast to lowercase. This also is available for **scans**, but not **petscans** or **assessors**.
+The optional **keep_multis** field may be *all* (the default); or *first*. This applies when there are multiple scans in the session that match as possible inputs. Normally one assessor is built for each matching scan. When *first* is specified, only one assessor will be built, using the first matching scan as its input. "First" is defined as alphabetical order by scan ID, cast to lowercase. The exact scan type is not considered; only whether there is a match with the **types** specified. This also is available for **scans**, but not **petscans** or **assessors**.
 
 
 xnat assessors

--- a/docs/processors.rst
+++ b/docs/processors.rst
@@ -121,7 +121,7 @@ Optional fields for a resource are **fmatch** and **fcount**. **fmatch** defines
 
 The optional **skip_unusable** field may be *False* (the default); or *True* to prevent building assessors that would have as an input a scan that is marked *unusable*. This is available for **scans**, but not **petscans** or **assessors**.
 
-The optional **keep_multis** field may be *all* (the default); or *first*. This applies when there are multiple scans in the session that match as possible inputs. Normally all matching scans are used as inputs, multiplying assessors as needed. When *first* is specified, only the first matching scan will be used as an input, reducing the number of assessors built by a factor of the number of matching scans. "First" is defined as alphabetical order by scan ID, cast to lowercase. The exact scan type is not considered; only whether there is a match with the **types** specified. This also is available for **scans**, but not **petscans** or **assessors**.
+The optional **keep_multis** field may be *all* (the default); or *first*. This applies when there are multiple scans in the session that match as possible inputs. Normally all matching scans are used as inputs, multiplying assessors as needed. When *first* is specified, only the first matching scan will be used as an input, reducing the number of assessors built by a factor of the number of matching scans. "First" is defined as alphabetical order by scan ID, cast to lowercase. The exact scan type is not considered; only whether there is a match with the **types** specified. This is available for **scans**, but not **petscans** or **assessors**.
 
 
 xnat assessors

--- a/docs/processors_v3.rst
+++ b/docs/processors_v3.rst
@@ -1,0 +1,227 @@
+DAX Processors, version 3
+===========
+
+-----
+About
+-----
+DAX pipelines are defined by creating YAML text files. If you are not familiar with YAML, start here:
+https://learnxinyminutes.com/docs/yaml/.
+
+A processor YAML file defines the Environment, Inputs, Commands, and Outputs of your pipeline.
+
+Version 3 processors have a number of new options and conveniences.
+
+----------------
+Processor Repos
+----------------
+There are several existing processors that can be used without modification. The processors in these
+repositories can also provide valuable examples.
+
+https://github.com/VUIIS/dax_yaml_processor_examples
+
+https://github.com/VUIIS/yaml_processors (private, internal use only)
+
+----------------
+Overview
+----------------
+The processor file defines how a script to run a pipeline should be created. DAX will use the processor to generate scripts to be submitted to your cluster as jobs. The script will contain the
+commands to download the inputs from XNAT, run the pipeline, and prepare the results to be uploaded back to XNAT (the actual uploading is performed by DAX via *dax upload*).
+
+----------------
+A "Simple" Example
+----------------
+.. Let's start with a minimal example that we'll walk through first. Then we'll cover more advanced topics.
+
+.. code-block:: yaml
+
+---
+procyamlversion: 3.0.0-dev.0                 # Indicates to run as a v3 processor
+
+containers:                                  # Containers we will ref in the command section
+  - name: EXAMP                                  # Reference by this name in command section
+    path: example_v2.0.0.sif                     # Name/path that is replaced in command section
+    source: docker://vuiiscci/example:v2.0.0     # Not used, but good practice to set it
+
+reqs:  # Requirements for the cluster node, substituted into SBATCH section of job template
+  walltime: 0-2  # Time to request - SLURM supports the format DAYS-HOURS
+  memory: 16G
+
+inputs:
+  vars: {}   # Keyvalues to substitute in the command, for passing static settings
+      param1: param1value
+  xnat:
+    attrs:  # Calues to extract from xnat at the specified level of the current instance
+      - varname:  # Name to be used to dereference later
+        object:   # Source, one of these strings: project, subject, session, scan, assessor
+        attr:     # Name of the field in xnat
+        ref:      # From which object in inputs scans or assessors, referred to by name
+    scans:
+      - name: scan_fmri       # the name of this scan to dereference later
+        types: fMRI_run*      # the scan types to match on the session in XNAT
+        nifti: fmri.nii.gz    # Shortcut to download file in NIFTI resource as fmri.nii.gz
+        resources:            # To get files in other resources
+          - resource: EDAT        # Name of the resource
+            fdest: edat.txt       # Download the file as edat.txt
+
+outputs:
+  - pdf: report*.pdf        # Matching file uploaded to PDF resource
+  - stats: stats.txt        # Matching file uploaded to STATS resource
+  - dir: PREPROC            # Matching directory (PREPROC) uploaded to PREPROC resource
+  - path: inputpathname     # General purpose for other outputs
+    type: DIR                   # Type is FILE or DIR
+    resource: RESOURCENAME      # Store it in resource RESOURCENAME
+
+# Available commands are 'singularity_run' and 'singularity_exec'. These include default
+# flags --contain --cleanenv, and mount points for temp space plus INPUTS and OUTPUTS
+command:
+  type: singularity_run
+  extraopts: []       # Appends to default options for the run command
+  container: EXAMP    # Name of the container in the list above
+  args: null          # Arguments to the container itself
+
+description: |
+  Example description that gets printed to every PDF created by this processor
+  1. step 1 does something cool
+  2. step 2 does this other thing
+
+# Specify the job template to use (examples: https://github.com/VUIIS/dax_templates/)
+job_template: job_template_v3.txt
+
+
+----------------
+Parts of the Processor YAML
+----------------
+
+--------------------
+inputs (required)
+--------------------
+The **inputs** section defines the files and parameters to be prepared for the pipeline. Currently, the only subsections of inputs supported are **vars** and **xnat**.
+
+The **vars** subsection can store parameters to be passed as pipeline options, such as smoothing kernel size, etc that may be more conveniently coded here to substitute into the command arguments.
+
+The **xnat** section defines the files, directories or values that are extracted from XNAT and passed to the command. Currently, the subsections of **xnat** that are supported are **scans**, **assessors**, **attrs**, and **filters**. Each of these subsections contains an array with a specific set of fields for each item in the array.
+
+
+xnat scans
+---------------
+Each **xnat scans** item requires a **types** field. The **types** field is used to match against the scan type attribute on XNAT. The value can be a single string or a comma-separated list. Wildcards are also supported.
+
+The **resources** subsection of each xnat scan should contain a list of resources to download from the matched scan. Each resource requires fields for **ftype** and **var**. 
+
+**ftype** specifies what type to downloaded from the resource, either *FILE*, *DIR*, or *DIRJ*. *FILE* will download individual files from the resource. *DIR* will download the whole directory from the resource with the hierarchy maintained. *DIRJ* will also download the directory but strips extraneous intermediate directories from the produced path as implemented by the *-j* flag of unzip.
+
+The **var** field defines tags to be replaced in the **command** string template (see below).
+
+The optional **fmatch** field defines a regular expression to apply to filter the list of filenames in the resource. **fmulti** affects how inputs are handled when there are multiple matching files in a resource. By default, this situation causes an exception, but if **fmulti** is set to *any1*, a single (arbitrary) file is selected from the matching files instead.
+
+By default, any scan that matches will be included as an available input. Several optional settings affect this:
+
+- If **needs_qc** is *True*, assessors that would have an *unusable* scan as an input will be created, but will not run.
+
+- If **skip_unusable** is *True*, assessors that would have an *unusable* scan as an input will not even be created.
+
+- **keep_multis** may be *all* (the default); or *first*. This applies when there are multiple scans in the session that match as possible inputs. Normally all matching scans are used as inputs, multiplying assessors as needed. When *first* is specified, only the first matching scan will be used as an input, reducing the number of assessors built by a factor of the number of matching scans. "First" is defined as alphabetical order by scan ID, cast to lowercase. The exact scan type is not considered; only whether there is a match with the **types** specified.
+
+
+xnat assessors
+---------------
+Each xnat assessor item requires a **proctype** field. The **proctype** field is used to match against the assessor proctype attribute on XNAT. The value can be a single string or a comma-separated list. Wildcards are also supported.
+
+By default, any assessor that matches **proctype** will be included. However if **needs_qc** is set to *True*, assessors with a qcstatus of "Needs QA", "Bad", "Failed", "Poor", or "Do Not Run" will be excluded.
+
+The **resources** subsection of each xnat assessor should contain a list of resources to download from the matched scan. Each resource requires fields for **ftype** and **var**. 
+
+The **ftype** specifies what type to downloaded from the resource, either *FILE*, *DIR*, or *DIRJ*. *FILE* will download individual files from the resource. *DIR* will download the whole directory from the resource with the hierarchy maintained. *DIRJ* will also download the directory but strips extraneous intermediate directories from the produced path as impelemented by the "-j" flag of unzip.
+
+The **var** field defines the tag to be replaced in the **command** string template (see below).
+
+Optional fields for a resource are fmatch, fdest and fcount. fmatch defines a regular expression to apply to filter the list of filenames in the resource. fcount can be used to limit the number of files matched. By default, only 1 file is downloaded.  
+The inputs for some containers are expected to be in specific locations with specific filenames. This is accomplished using the **fdest** field. The file or directory gets copied to /INPUTS and renamed to the name specified in **fdest**. 
+
+
+xnat attrs
+---------------
+You can evaluate attributes at the subject, session, or scan level. Any fields that are accessible via the XNAT API can be queried. Each **attrs** item should contain a **varname**, **object**, and **attr**.
+**varname** specifies the tag to be replaced in the **command** string template. **object** is the XNAT object type to query and can be either *subject*, *session*, or *scan*. **attr** is the XNAT field to query. If the object type is *scan*, then a scan name from the xnat scans section must be included with the **ref** field.
+
+For example:
+
+.. code-block:: yaml
+
+  attrs:
+      - varname: project
+        object: session
+        attr: project
+
+  # Or equivalently
+  attrs:
+      - {varname: project, object: assessor, attr: project}
+        
+This will extract the value of the project attribute from the assessor object and replace {project} in the command template.
+
+
+xnat filters
+------------------
+**filters** allows you to filter a subset of the cartesian product of the matched scans and assessors. Currently, the only filter implemented is a match filter. It will only create the assessors where the specified list of inputs match. This is used when you want to link a set of assessors that all use the same initial scan as input.
+
+For example:
+
+.. code-block:: yaml
+
+  filters:
+      - type: match
+        inputs: scan_t1,assr_freesurfer/scan_t1
+
+This will tell DAX to only run this pipeline where the value for scan_t1 and assr_freesurfer/scan_t1 are the same scan.
+
+
+outputs
+--------------------
+The **outputs** section defines a list files or directories to be uploaded to XNAT upon completion of the pipeline. Each output item must contain fields **path**, **type**, and **resource**. The **path** value contains the local relative path of the file or directory to be uploaded. The type of the path should either be *FILE* or *DIR*. The **resource** is the name of resource of the assessor created on XNAT where the output is to be uploaded.
+
+For every processor, a *PDF* output with **resource** named PDF is required and must be of type *FILE*.
+
+*PDF* and *STATS* outputs, as well as *DIR* type outputs, have shortcuts as shown in the example.
+
+
+command
+--------------------
+The **command** field defines a string template that is formatted using the values from **inputs**.
+
+Each tag specified inside curly braces ("{}"") corresponds to a field in the **defaults** input section, or to a **var** field from a resource on an input or to a **varname** in the xnat attrs section.
+
+See the example for explanations of the other fields.
+
+
+jobtemplate
+--------------------
+The **jobtemplate** is a text file that contains a template to create a batch job script. 
+
+-------------------
+Versioning
+-------------------
+Processor name and version are parsed from the processor file name, based on the format
+<NAME>_v<major.minor.revision>.yaml. <NAME>_v<major> will be used as the proctype.
+
+
+-------------------
+Notes on singularity options
+-------------------
+The default options are *SINGULARITY_BASEOPTS* in dax/dax/processors_v3.py:
+
+    --contain --cleanenv
+    --home $JOBDIR
+    --bind $INDIR:/INPUTS
+    --bind $OUTDIR:/OUTPUTS
+    --bind $JOBDIR:/tmp
+    --bind $JOBDIR:/dev/shm
+
+$JOBDIR, $INDIR, $OUTDIR are available at run time, and refer to locations on the filesystem of the node where the job is running.
+
+Singularity has default binds that differ between installations. --contain disables these to prevent cross-talk with the host filesystem. And --cleanenv prevents cross-talk with the host environment. However, with --contain, some spiders will need to have specific temp space on the host attached. E.g. for some versions of Freesurfer, --bind ${INDIR}:/dev/shm. For compiled Matlab spiders, we need to provide --home $INDIR to avoid .mcrCache collisions in temp space when multiple spiders are running. And, some cases may require ${INDIR}:/tmp or /tmp:/tmp. Thus the defaults above.
+
+The entire singularity command is built as
+
+    singularity <run|exec> <SINGULARITY_BASEOPTS> <extraopts> <container> <args>
+
+

--- a/docs/processors_v3.rst
+++ b/docs/processors_v3.rst
@@ -28,64 +28,63 @@ The processor file defines how a script to run a pipeline should be created. DAX
 commands to download the inputs from XNAT, run the pipeline, and prepare the results to be uploaded back to XNAT (the actual uploading is performed by DAX via *dax upload*).
 
 ----------------
-A "Simple" Example
+A Basic Example
 ----------------
-.. Let's start with a minimal example that we'll walk through first. Then we'll cover more advanced topics.
 
 .. code-block:: yaml
-
----
-procyamlversion: 3.0.0-dev.0                 # Indicates to run as a v3 processor
-
-containers:                                  # Containers we will ref in the command section
-  - name: EXAMP                                  # Reference by this name in command section
-    path: example_v2.0.0.sif                     # Name/path that is replaced in command section
-    source: docker://vuiiscci/example:v2.0.0     # Not used, but good practice to set it
-
-reqs:  # Requirements for the cluster node, substituted into SBATCH section of job template
-  walltime: 0-2  # Time to request - SLURM supports the format DAYS-HOURS
-  memory: 16G
-
-inputs:
-  vars: {}   # Keyvalues to substitute in the command, for passing static settings
-      param1: param1value
-  xnat:
-    attrs:  # Calues to extract from xnat at the specified level of the current instance
-      - varname:  # Name to be used to dereference later
-        object:   # Source, one of these strings: project, subject, session, scan, assessor
-        attr:     # Name of the field in xnat
-        ref:      # From which object in inputs scans or assessors, referred to by name
-    scans:
-      - name: scan_fmri       # the name of this scan to dereference later
-        types: fMRI_run*      # the scan types to match on the session in XNAT
-        nifti: fmri.nii.gz    # Shortcut to download file in NIFTI resource as fmri.nii.gz
-        resources:            # To get files in other resources
-          - resource: EDAT        # Name of the resource
-            fdest: edat.txt       # Download the file as edat.txt
-
-outputs:
-  - pdf: report*.pdf        # Matching file uploaded to PDF resource
-  - stats: stats.txt        # Matching file uploaded to STATS resource
-  - dir: PREPROC            # Matching directory (PREPROC) uploaded to PREPROC resource
-  - path: inputpathname     # General purpose for other outputs
-    type: DIR                   # Type is FILE or DIR
-    resource: RESOURCENAME      # Store it in resource RESOURCENAME
-
-# Available commands are 'singularity_run' and 'singularity_exec'. These include default
-# flags --contain --cleanenv, and mount points for temp space plus INPUTS and OUTPUTS
-command:
-  type: singularity_run
-  extraopts: []       # Appends to default options for the run command
-  container: EXAMP    # Name of the container in the list above
-  args: null          # Arguments to the container itself
-
-description: |
-  Example description that gets printed to every PDF created by this processor
-  1. step 1 does something cool
-  2. step 2 does this other thing
-
-# Specify the job template to use (examples: https://github.com/VUIIS/dax_templates/)
-job_template: job_template_v3.txt
+    
+    ---
+    procyamlversion: 3.0.0-dev.0                 # Indicates to run as a v3 processor
+    
+    containers:                                  # Containers we will ref in the command section
+      - name: EXAMP                                  # Reference by this name in command section
+        path: example_v2.0.0.sif                     # Name/path that is replaced in command section
+        source: docker://vuiiscci/example:v2.0.0     # Not used, but good practice to set it
+    
+    reqs:  # Requirements for the cluster node, substituted into SBATCH section of job template
+      walltime: 0-2  # Time to request - SLURM supports the format DAYS-HOURS
+      memory: 16G
+    
+    inputs:
+      vars: {}   # Keyvalues to substitute in the command, for passing static settings
+          param1: param1value
+      xnat:
+        attrs:  # Calues to extract from xnat at the specified level of the current instance
+          - varname:  # Name to be used to dereference later
+            object:   # Source, one of these strings: project, subject, session, scan, assessor
+            attr:     # Name of the field in xnat
+            ref:      # From which object in inputs scans or assessors, referred to by name
+        scans:
+          - name: scan_fmri       # the name of this scan to dereference later
+            types: fMRI_run*      # the scan types to match on the session in XNAT
+            nifti: fmri.nii.gz    # Shortcut to download file in NIFTI resource as fmri.nii.gz
+            resources:            # To get files in other resources
+              - resource: EDAT        # Name of the resource
+                fdest: edat.txt       # Download the file as edat.txt
+    
+    outputs:
+      - pdf: report*.pdf        # Matching file uploaded to PDF resource
+      - stats: stats.txt        # Matching file uploaded to STATS resource
+      - dir: PREPROC            # Matching directory (PREPROC) uploaded to PREPROC resource
+      - path: inputpathname     # General purpose for other outputs
+        type: DIR                   # Type is FILE or DIR
+        resource: RESOURCENAME      # Store it in resource RESOURCENAME
+    
+    # Available commands are 'singularity_run' and 'singularity_exec'. These include default
+    # flags --contain --cleanenv, and mount points for temp space plus INPUTS and OUTPUTS
+    command:
+      type: singularity_run
+      extraopts: []       # Appends to default options for the run command
+      container: EXAMP    # Name of the container in the list above
+      args: null          # Arguments to the container itself
+    
+    description: |
+      Example description that gets printed to every PDF created by this processor
+      1. step 1 does something cool
+      2. step 2 does this other thing
+    
+    # Specify the job template to use (examples: https://github.com/VUIIS/dax_templates/)
+    job_template: job_template_v3.txt
 
 
 ----------------

--- a/docs/processors_v3.rst
+++ b/docs/processors_v3.rst
@@ -130,7 +130,7 @@ By default, any scan that matches will be included as an available input. Severa
 
 - If **skip_unusable** is *True*, assessors that would have an *unusable* scan as an input will not even be created.
 
-- **keep_multis** may be *all* (the default); or *first*. This applies when there are multiple scans in the session that match as possible inputs. Normally all matching scans are used as inputs, multiplying assessors as needed. When *first* is specified, only the first matching scan will be used as an input, reducing the number of assessors built by a factor of the number of matching scans. "First" is defined as alphabetical order by scan ID, cast to lowercase. The exact scan type is not considered; only whether there is a match with the **types** specified.
+- **keep_multis** may be *all* (the default); *first*; *last*; or an index 1,2,3,... This applies when there are multiple scans in the session that match as possible inputs. Normally all matching scans are used as inputs, multiplying assessors as needed. When *first* is specified, only the first matching scan will be used as an input, reducing the number of assessors built by a factor of the number of matching scans. "First" is defined as alphabetical order by scan ID, cast to lowercase. The exact scan type is not considered; only whether there is a match with the **types** specified.
 
 
 xnat assessors


### PR DESCRIPTION
Fixes #352.

Adding two new options for yaml processors, for the section inputs.xnat.scans. Neither is required to be present.

`keep_multis` can be `all` (to obtain current behavior); or `first`, in which case when multiple scans with the same scan type are found as potential inputs to an assessor, only the first one is kept in the list. "First" is defined as first in alphabetical order by the scan ID string.

`skip_unusable` can be `False` (to obtain current behavior where assessors are built for unusable scans but marked Unusable in the QC field); or `True`, in which case assessors are just not not built for scans that are marked unusable.

These options are not implemented for inputs.xnat.petscans or inputs.xnat.assessors.

TESTED in a session with two same-named T1 scans:

Testing skip_unusable:
  With existing yaml options:
    OK - Regular build no extras, T1s both usable, expect two assessors at NEED_INPUTS
    OK - First T1 unusable and no needs_qc - expect two assessors at NEED_INPUTS
    OK - First T1 unusable WITH needs_qc - expect two assessors but one marked unusable
  With new skip_unusable field set in the yaml (but not needs_qc):
    OK - Build with first T1 unusable - expect only 1 assessor.
    OK - Build with both T1 usable. Expect 2 assessors at NEED_INPUTS
  
Testing keep_multis:
  OK - Set keep_multis 'all', T1s both usable, no needs_qc, no skip_unusable, expect two assrs at NEED_INPUTS
  OK - Same but keep_multis 'first', expect one assr for first T1
