### PR TITLE
Processor v3 pre/post

### DIFF
--- a/bin/dax_tools/dax
+++ b/bin/dax_tools/dax
@@ -100,7 +100,8 @@ def parse_args():
         '-n',
         dest='max_threads',
         help='Max Upload Threads',
-        default='1')
+        type=int,
+        default=1)
     upload_parser.add_argument(
         '--host', dest='host', help='XNAT Host. Default: $XNAT_HOST')
     upload_parser.add_argument(

--- a/bin/dax_tools/dax
+++ b/bin/dax_tools/dax
@@ -220,8 +220,8 @@ if __name__ == '__main__':
         print('ALL DONE!')
 
     elif args.command == 'undo':
-        # Undo the assessor
-        dax.bin.undo_assessor(args.assessor)
+        # Undo the processing of the assessor
+        dax.bin.undo_processing(args.assessor)
         print('ALL DONE!')
 
     elif args.command == 'version':

--- a/bin/dax_tools/dax
+++ b/bin/dax_tools/dax
@@ -220,8 +220,12 @@ if __name__ == '__main__':
         print('ALL DONE!')
 
     elif args.command == 'undo':
-        # Undo the processing of the assessor
-        dax.bin.undo_processing(args.assessor)
+        try:
+            logger.info('connecting to xnat for undo')
+            with XnatUtils.get_interface(xnat_host) as xnat:
+                # Undo the processing of the assessor
+                dax.bin.undo_processing(xnat, args.assessor)
+
         print('ALL DONE!')
 
     elif args.command == 'version':

--- a/bin/dax_tools/dax
+++ b/bin/dax_tools/dax
@@ -185,6 +185,7 @@ if __name__ == '__main__':
         if args.settings_path:
             # TODO: allow flag to use settings dir which will upload all the 
             # settings files in the directory
+            enable_stdout()
             dax.bin.upload(args.settings_path)
         else:
             dax_tools.upload_tasks(

--- a/bin/dax_tools/dax
+++ b/bin/dax_tools/dax
@@ -12,7 +12,6 @@ import os
 import dax
 from dax import dax_tools_utils as dax_tools
 from dax import dax_manager
-from dax.XnatUtils import get_interface
 
 __author__ = "Benjamin Yvernault"
 __description__ = "Main python executable for dax."
@@ -230,9 +229,8 @@ if __name__ == '__main__':
     elif args.command == 'undo':
         try:
             enable_stdout()
-            with get_interface() as xnat:
-                # Undo the processing of the assessor
-                dax.bin.undo_processing(xnat, args.assessor)
+            # Undo the processing of the assessor
+            dax.bin.undo_processing(args.assessor)
         except Exception as err:
             print('error undo:{}'.format(err))
 

--- a/bin/dax_tools/dax
+++ b/bin/dax_tools/dax
@@ -97,6 +97,11 @@ def parse_args():
         nargs='?',
         default='')
     upload_parser.add_argument(
+        '-n',
+        dest='max_threads',
+        help='Max Upload Threads',
+        default='1')
+    upload_parser.add_argument(
         '--host', dest='host', help='XNAT Host. Default: $XNAT_HOST')
     upload_parser.add_argument(
         '-u', '--username', dest='username', help='Username for XNAT')
@@ -186,7 +191,7 @@ if __name__ == '__main__':
             # TODO: allow flag to use settings dir which will upload all the 
             # settings files in the directory
             enable_stdout()
-            dax.bin.upload(args.settings_path)
+            dax.bin.upload(args.settings_path, max_threads=args.max_threads)
         else:
             dax_tools.upload_tasks(
                 args.logfile, args.debug, args.upload_settings, args.host,

--- a/bin/dax_tools/dax
+++ b/bin/dax_tools/dax
@@ -221,7 +221,6 @@ if __name__ == '__main__':
 
     elif args.command == 'undo':
         try:
-            logger.info('connecting to xnat for undo')
             with XnatUtils.get_interface(xnat_host) as xnat:
                 # Undo the processing of the assessor
                 dax.bin.undo_processing(xnat, args.assessor)

--- a/bin/dax_tools/dax
+++ b/bin/dax_tools/dax
@@ -141,6 +141,11 @@ runs build, launch, update and upload.'
     setup_desc = 'Set up dax on your computer'
     dax_parser.add_parser('setup', help=setup_desc)
 
+    # undo:
+    undo_desc = 'Undo processing, reset the assessor to NEED_INPUTS'
+    undo_parser = dax_parser.add_parser('undo', help=undo_desc)
+    undo_parser.add_argument(dest='assessor', help='Assessor Label to Undo')
+
     # version:
     version_desc = 'Print dax version.'
     dax_parser.add_parser('version', help=version_desc)
@@ -212,6 +217,11 @@ if __name__ == '__main__':
         else:
             print('This instance is currently disabled in REDCap.')
 
+        print('ALL DONE!')
+
+    elif args.command == 'undo':
+        # Undo the assessor
+        dax.bin.undo_assessor(args.assessor)
         print('ALL DONE!')
 
     elif args.command == 'version':

--- a/bin/dax_tools/dax
+++ b/bin/dax_tools/dax
@@ -226,7 +226,7 @@ if __name__ == '__main__':
                 # Undo the processing of the assessor
                 dax.bin.undo_processing(xnat, args.assessor)
         except Exception as err:
-            logger.error('error undo:{}'.format(err))
+            print('error undo:{}'.format(err))
 
     elif args.command == 'version':
         print(dax.__version__)

--- a/bin/dax_tools/dax
+++ b/bin/dax_tools/dax
@@ -101,7 +101,8 @@ def parse_args():
         dest='max_threads',
         help='Max Upload Threads',
         type=int,
-        default=1)
+        default=1,
+        choices=range(1, 10))
     upload_parser.add_argument(
         '--host', dest='host', help='XNAT Host. Default: $XNAT_HOST')
     upload_parser.add_argument(

--- a/bin/dax_tools/dax
+++ b/bin/dax_tools/dax
@@ -229,6 +229,7 @@ if __name__ == '__main__':
 
     elif args.command == 'undo':
         try:
+            enable_stdout()
             with get_interface() as xnat:
                 # Undo the processing of the assessor
                 dax.bin.undo_processing(xnat, args.assessor)

--- a/bin/dax_tools/dax
+++ b/bin/dax_tools/dax
@@ -221,7 +221,7 @@ if __name__ == '__main__':
 
     elif args.command == 'undo':
         try:
-            with get_interface(xnat_host) as xnat:
+            with get_interface() as xnat:
                 # Undo the processing of the assessor
                 dax.bin.undo_processing(xnat, args.assessor)
         except Exception as err:

--- a/bin/dax_tools/dax
+++ b/bin/dax_tools/dax
@@ -225,8 +225,8 @@ if __name__ == '__main__':
             with XnatUtils.get_interface(xnat_host) as xnat:
                 # Undo the processing of the assessor
                 dax.bin.undo_processing(xnat, args.assessor)
-
-        print('ALL DONE!')
+        except Exception as err:
+            logger.error('error undo:{}'.format(err))
 
     elif args.command == 'version':
         print(dax.__version__)

--- a/bin/dax_tools/dax
+++ b/bin/dax_tools/dax
@@ -12,7 +12,7 @@ import os
 import dax
 from dax import dax_tools_utils as dax_tools
 from dax import dax_manager
-
+from dax.XnatUtils import get_interface
 
 __author__ = "Benjamin Yvernault"
 __description__ = "Main python executable for dax."
@@ -221,7 +221,7 @@ if __name__ == '__main__':
 
     elif args.command == 'undo':
         try:
-            with XnatUtils.get_interface(xnat_host) as xnat:
+            with get_interface(xnat_host) as xnat:
                 # Undo the processing of the assessor
                 dax.bin.undo_processing(xnat, args.assessor)
         except Exception as err:

--- a/dax/XnatUtils.py
+++ b/dax/XnatUtils.py
@@ -442,11 +442,27 @@ class InterfaceTemp(Interface):
                                             session=session,
                                             assessor=assessor)
 
+    def get_sgp_assessor_path(self, project, subject, assessor):
+        """Given project, subject, assessor (strings),
+           returns assessor path (string)
+        """
+        return '/projects/{}/subjects/{}/assessors/{}'.format(
+            project=project,
+            subject=subject,
+            assessor=assessor)
+
     def select_assessor(self, project, subject, session, assessor):
         """Given project, subject, session, assessor (strings),
            returns assessor object
         """
         xpath = self.get_assessor_path(project, subject, session, assessor)
+        return self.select(xpath)
+
+    def select_sgp_assessor(self, project, subject, assessor):
+        """Given project, subject, assessor (strings),
+           returns assessor object
+        """
+        xpath = self.get_sgp_assessor_path(project, subject, assessor)
         return self.select(xpath)
 
     def get_assessor_resource_path(

--- a/dax/assessor_utils.py
+++ b/dax/assessor_utils.py
@@ -1,22 +1,13 @@
-
-import pyxnat
 import re
-import os
+
 
 SGP_PATTERN = '\w+-x-\w+-x-\w+_v[0-9]+-x-[0-9a-f]+'
 
 
-def __pyxnat_assessor_type():
-    return pyxnat.core.resources.Assessor
+def full_label(project, subject, session, assessor):
+    return '-x-'.join([project, subject, session, assessor])
 
 
-def full_label(project_id, subject_id, session_id,
-               assessor_label):
-    return '-x-'.join([project_id, subject_id, session_id, assessor_label])
-
-
-# TODO: BenM/assessor_of_assessor/behaviour contingent on assessor version;
-# the name shouldn't be used to test this
 def full_label_from_assessor(assessor):
     assessor_label = assessor.label()
     if '-x-' in assessor_label:
@@ -64,6 +55,6 @@ def parse_full_assessor_name(assessor_name):
     return assrdict
 
 
-def is_sgp_assessor(dirpath):
-    # PROJECT-x-SUBJECT-x-PROCTYPE-x-UID
-    return re.match(SGP_PATTERN, os.path.basename(dirpath))
+def is_sgp_assessor(assessor):
+    # Try to match the assessor label with the SGP pattern
+    return re.match(SGP_PATTERN, assessor)

--- a/dax/bin.py
+++ b/dax/bin.py
@@ -446,15 +446,12 @@ def upload(settings_path, max_upload=1):
 
 
 def upload_thread(xnat_host, pindex, assessor_label, pcount, resdir):
-    # TODO: how do we want to name the lock files such that they get re-used?
-
     # TODO: move this and associated functions to launcher
     logger = logging.getLogger('dax')
 
     lock_dir = os.path.join(resdir, 'FlagFiles')
 
-    # Get lock file name based on index number
-    #lock_file = os.path.join(lock_dir, 'Upload_{}.txt'.format(pindex + 1))
+    # Get lock file name
     lock_file = os.path.join(lock_dir, '{}_Upload.txt'.format(assessor_label))
 
     # Try to lock

--- a/dax/bin.py
+++ b/dax/bin.py
@@ -420,14 +420,14 @@ def upload(settings_path, max_upload=1):
     lock_list = os.listdir(lock_dir)
     lock_list = [x for x in lock_list if x.endswith('_Upload.txt')]
     cur_upload_count = len(lock_list)
-    LOGGER.info('count of already running uploads:' + str(cur_upload_count))
+    logger.info('count of already running uploads:' + str(cur_upload_count))
 
     num_threads = max_upload - cur_upload_count
     if num_threads < 1:
-        LOGGER.info('max uploads already:{}'.format(str(cur_upload_count)))
+        logger.info('max uploads already:{}'.format(str(cur_upload_count)))
         return
     
-    LOGGER.info('starting {} upload thread(s)'.format(str(num_threads)))
+    logger.info('starting {} upload thread(s)'.format(str(num_threads)))
     sys.stdout.flush()
 
     pool = Pool(processes=num_threads)
@@ -500,6 +500,8 @@ def upload_thread(xnat_host, pindex, assessor_label, pcount, resdir):
 
 # TODO: move these lock file routines to a shared file
 def clean_lockfiles(lock_dir):
+    logger = logging.getLogger('dax')
+
     lock_list = os.listdir(lock_dir)
 
     # Make full paths
@@ -507,11 +509,13 @@ def clean_lockfiles(lock_dir):
 
     # Check each lock file
     for file in lock_list:
-        LOGGER.debug('checking lock file:{}'.format(file))
+        logger.debug('checking lock file:{}'.format(file))
         check_lockfile(file)
 
 
 def check_lockfile(file):
+    logger = logging.getLogger('dax')
+
     # Try to read host-PID from lockfile
     try:
         with open(file, 'r') as f:
@@ -523,16 +527,16 @@ def check_lockfile(file):
         # Compare host to current host
         this_host = socket.gethostname().split('.')[0]
         if host != this_host:
-            LOGGER.debug('different host, cannot check PID:{}', format(file))
+            logger.debug('different host, cannot check PID:{}', format(file))
         elif pid_exists(pid):
-            LOGGER.debug('host matches and PID exists:{}'.format(str(pid)))
+            logger.debug('host matches and PID exists:{}'.format(str(pid)))
         else:
-            LOGGER.debug('host matches and PID not running, deleting lockfile')
+            logger.debug('host matches and PID not running, deleting lockfile')
             os.remove(file)
     except IOError:
-        LOGGER.debug('failed to read from lock file:{}'.format(file))
+        logger.debug('failed to read from lock file:{}'.format(file))
     except ValueError:
-        LOGGER.debug('failed to parse lock file:{}'.format(file))
+        logger.debug('failed to parse lock file:{}'.format(file))
 
 
 def lock_flagfile(lock_file):

--- a/dax/bin.py
+++ b/dax/bin.py
@@ -567,7 +567,7 @@ def unlock_flagfile(lock_file):
         os.remove(lock_file)
 
 
-def undo_processing(assessor_label, logger=None, xnat=None):
+def undo_processing(xnat, assessor_label, logger=None):
     """
     Unset job information for the assessor on XNAT, Delete files, set to run.
 

--- a/dax/bin.py
+++ b/dax/bin.py
@@ -536,6 +536,19 @@ def check_lockfile(file):
         logger.debug('failed to parse lock file:{}'.format(file))
 
 
+def pid_exists(pid):
+    if pid < 0:
+        return False   # NOTE: pid == 0 returns True
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:   # errno.ESRCH
+        return False  # No such process
+    except PermissionError:  # errno.EPERM
+        return True  # Operation not permitted (i.e., process exists)
+    else:
+        return True  # no error, we can send a signal to the process
+
+
 def lock_flagfile(lock_file):
     """
     Create the flagfile to lock the process

--- a/dax/bin.py
+++ b/dax/bin.py
@@ -390,7 +390,7 @@ def load_from_file(filepath, args, logger, singularity_imagedir=None, job_templa
     return None
 
 
-def upload(settings_path, max_upload=1):
+def upload(settings_path, max_threads=1):
     logger = logging.getLogger('dax')
 
     # Load settings from file
@@ -422,7 +422,7 @@ def upload(settings_path, max_upload=1):
     cur_upload_count = len(lock_list)
     logger.info('count of already running uploads:' + str(cur_upload_count))
 
-    num_threads = max_upload - cur_upload_count
+    num_threads = max_threads - cur_upload_count
     if num_threads < 1:
         logger.info('max uploads already:{}'.format(str(cur_upload_count)))
         return

--- a/dax/bin.py
+++ b/dax/bin.py
@@ -464,7 +464,7 @@ def upload_thread(xnat_host, pindex, assessor_label, pcount, resdir):
             if assessor_utils.is_sgp_assessor(assessor_path):
                 # It's a subject gen proc assessor, handle it specifically
                 dax_tools_utils.upload_assessor_subjgenproc(
-                    xnat, assessor_path, delete=False)
+                    xnat, assessor_path)
             else:
                 assessor_dict = assessor_utils.parse_full_assessor_name(
                     assessor_label)

--- a/dax/dax_manager.py
+++ b/dax/dax_manager.py
@@ -738,7 +738,7 @@ class DaxManager(object):
 
         # Queue each assessor to be uploaded
         for pindex, alabel in enumerate(assessors_list):
-            upload_results[i] = upload_pool.apply_async(
+            upload_results[pindex] = upload_pool.apply_async(
                 run_upload_thread,
                 [logfile, xnat_host, pindex, alabel, pcount, resdir])
 

--- a/dax/dax_manager.py
+++ b/dax/dax_manager.py
@@ -814,7 +814,7 @@ class DaxManager(object):
             lock_list = os.listdir(self.lock_dir)
             lock_list = [x for x in lock_list if x.endswith('_Upload.txt')]
             cur_upload_count = len(lock_list)
-            logger.info('count of running uploads:{}'.format(cur_upload_count))
+            LOGGER.info('count of running uploads:{}'.format(cur_upload_count))
 
             num_upload_threads = max_upload_count - cur_upload_count
             if num_upload_threads < 1:

--- a/dax/dax_manager.py
+++ b/dax/dax_manager.py
@@ -938,8 +938,8 @@ class DaxManager(object):
 
 def run_upload_thread(logfile, xnat_host, pindex, alabel, pcount, resdir):
     logging.getLogger('dax').handlers = []
-    bin.set_logger(logfile, debug=True)
-    bin.upload_thread(xnat_host, pindex, alabel, pcount, resdir)
+    dax.bin.set_logger(logfile, debug=True)
+    dax.bin.upload_thread(xnat_host, pindex, alabel, pcount, resdir)
     logging.getLogger('dax').handlers = []
 
 

--- a/dax/dax_manager.py
+++ b/dax/dax_manager.py
@@ -256,9 +256,8 @@ class DaxProjectSettingsManager(object):
                     self.rebuild_projects.append(name)
 
             except DaxManagerError as e:
-                err = 'error in project settings:project={}\n{}'.format(
-                    project, e)
-                LOGGER.info(err)
+                err = 'invalid project settings:project={}:{}'.format(name, e)
+                LOGGER.error(traceback.format_exc())
                 errors.append(err)
 
         return errors
@@ -428,7 +427,8 @@ class DaxProjectSettingsManager(object):
                     key, val = arg.split(':', 1)
                     rdict[key] = val.strip()
                 except ValueError as e:
-                    msg = 'invalid arguments:{}'.format(e)
+                    msg = 'invalid arguments:{}:{}:{}:{}'.format(
+                        project, processor, arg, e)
                     raise DaxManagerError(msg)
 
             dax_rec['arguments'] = rdict

--- a/dax/dax_manager.py
+++ b/dax/dax_manager.py
@@ -888,7 +888,7 @@ class DaxManager(object):
         utilities.send_email_netrc(self.smtp_host, _to, _subj, _msg)
 
     def clean_lockfiles(self):
-        lockfiles.clean_lockfiles(self.lock_dir)
+        lockfiles.clean_lockfiles(self.lock_dir, LOGGER)
 
 
 def run_upload_thread(logfile, xnat_host, pindex, alabel, pcount, resdir):

--- a/dax/dax_manager.py
+++ b/dax/dax_manager.py
@@ -638,6 +638,7 @@ class DaxManager(object):
         self.smtp_host = instance_settings['main_smtphost']
         self.mode = instance_settings['main_mode']
         self.enabled = (instance_settings['main_complete'] == 'Complete')
+        self.xnat_host = instance_settings['main_xnathost']
 
         # Create our settings manager and update our settings directory
         self.settings_manager = DaxProjectSettingsManager(

--- a/dax/dax_tools_utils.py
+++ b/dax/dax_tools_utils.py
@@ -709,7 +709,7 @@ def upload_snapshots_subjgenproc(sassr, dirpath):
             params={"event_reason": "DAX upload"})
 
 
-def upload_assessor_subjgenproc(xnat, dirpath, delete=False):
+def upload_assessor_subjgenproc(xnat, dirpath):
     resdir = os.path.dirname(dirpath)
     diskq_dir = os.path.join(resdir, 'DISKQ')
     assr = os.path.basename(dirpath)
@@ -791,12 +791,11 @@ def upload_assessor_subjgenproc(xnat, dirpath, delete=False):
         'proc:subjgenprocdata/dax_version_hash': __git_revision__,
     })
 
-    if delete:
-        # Delete the task from diskq
-        ctask.delete()
+    # Delete the task from diskq
+    ctask.delete()
 
-        # Remove the folder
-        shutil.rmtree(dirpath)
+    # Remove the folder
+    shutil.rmtree(dirpath)
 
 
 def upload_thread(xnat, index, assessor_label, number_of_processes, resdir):
@@ -806,7 +805,7 @@ def upload_thread(xnat, index, assessor_label, number_of_processes, resdir):
 
     if assessor_utils.is_sgp_assessor(assessor_path):
         uploaded = upload_assessor_subjgenproc(
-            xnat, assessor_path, delete=False)
+            xnat, assessor_path)
     else:
         assessor_dict = assessor_utils.parse_full_assessor_name(assessor_label)
         if assessor_dict:

--- a/dax/dax_tools_utils.py
+++ b/dax/dax_tools_utils.py
@@ -803,7 +803,7 @@ def upload_thread(xnat, index, assessor_label, number_of_processes, resdir):
     msg = "    *Process: %s/%s -- label: %s / time: %s"
     LOGGER.info(msg % (str(index + 1),str(number_of_processes), assessor_label, str(datetime.now())))
 
-    if assessor_utils.is_sgp_assessor(assessor_path):
+    if assessor_utils.is_sgp_assessor(assessor_label):
         uploaded = upload_assessor_subjgenproc(
             xnat, assessor_path)
     else:

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -9,9 +9,9 @@ import logging
 import sys
 import os
 import traceback
-import socket
 import tempfile
 
+from . import lockfiles
 from . import processors, modules, XnatUtils, task, cluster, processors_v3
 from .task import Task, ClusterTask, XnatTask, mkdirp
 from .dax_settings import DAX_Settings, DAX_Netrc
@@ -1037,7 +1037,7 @@ The project is not part of the settings."""
                 LOGGER.error(mess_str)
                 exit(1)
         else:
-            success = self.lock_flagfile(flagfile)
+            success = lockfiles.lock_flagfile(flagfile)
             if not success:
                 LOGGER.warn('failed to get lock. Already running.')
                 exit(1)
@@ -1058,39 +1058,7 @@ The project is not part of the settings."""
         :return: None
         """
         if not project_local:
-            self.unlock_flagfile(flagfile)
-
-    @staticmethod
-    def lock_flagfile(lock_file):
-        """
-        Create the flagfile to lock the process
-
-        :param lock_file: flag file use to lock the process
-        :return: True if the file didn't exist, False otherwise
-        """
-        if os.path.exists(lock_file):
-            return False
-        else:
-            open(lock_file, 'w').close()
-
-            # Write hostname-PID to lock file
-            _pid = os.getpid()
-            _host = socket.gethostname().split('.')[0]
-            with open(lock_file, 'w') as f:
-                f.write('{}-{}'.format(_host, _pid))
-
-            return True
-
-    @staticmethod
-    def unlock_flagfile(lock_file):
-        """
-        Remove the flagfile to unlock the process
-
-        :param lock_file: flag file use to lock the process
-        :return: None
-        """
-        if os.path.exists(lock_file):
-            os.remove(lock_file)
+            lockfiles.unlock_flagfile(flagfile)
 
     def get_tasks(self, xnat, is_valid_assessor, project_list=None,
                   sessions_local=None):

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -450,7 +450,9 @@ cluster queue"
                                        mod_delta=mod_delta, lastrun=lastrun,
                                        start_sess=start_sess)
 
-                    self.build_project_subjgenproc(intf, project_id)
+                    if len(self.get_subjgenproc_processors(project_id)) > 0:
+                        # The project has SGP processors so we build them
+                        self.build_project_subjgenproc(intf, project_id)
 
                 except Exception as E:
                     err1 = 'Caught exception building project %s'

--- a/dax/lockfiles.py
+++ b/dax/lockfiles.py
@@ -1,0 +1,83 @@
+import socket
+import os
+
+
+def check_lockfile(file, logger):
+    # Try to read host-PID from lockfile
+    try:
+        with open(file, 'r') as f:
+            line = f.readline()
+
+        host, pid = line.split('-')
+        pid = int(pid)
+
+        # Compare host to current host
+        this_host = socket.gethostname().split('.')[0]
+        if host != this_host:
+            logger.debug('different host, cannot check PID:{}', format(file))
+        elif pid_exists(pid):
+            logger.debug('host matches and PID exists:{}'.format(str(pid)))
+        else:
+            logger.debug('host matches and PID not running, deleting lockfile')
+            os.remove(file)
+    except IOError:
+        logger.debug('failed to read from lock file:{}'.format(file))
+    except ValueError:
+        logger.debug('failed to parse lock file:{}'.format(file))
+
+
+def clean_lockfiles(lock_dir, logger):
+    lock_list = os.listdir(lock_dir)
+
+    # Make full paths
+    lock_list = [os.path.join(lock_dir, f) for f in lock_list]
+
+    # Check each lock file
+    for file in lock_list:
+        logger.debug('checking lock file:{}'.format(file))
+        check_lockfile(file, logger)
+
+
+def pid_exists(pid):
+    if pid < 0:
+        return False   # NOTE: pid == 0 returns True
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:   # errno.ESRCH
+        return False  # No such process
+    except PermissionError:  # errno.EPERM
+        return True  # Operation not permitted (i.e., process exists)
+    else:
+        return True  # no error, we can send a signal to the process
+
+
+def lock_flagfile(lock_file):
+    """
+    Create the flagfile to lock the process
+
+    :param lock_file: flag file use to lock the process
+    :return: True if the file didn't exist, False otherwise
+    """
+    if os.path.exists(lock_file):
+        return False
+    else:
+        open(lock_file, 'w').close()
+
+        # Write hostname-PID to lock file
+        _pid = os.getpid()
+        _host = socket.gethostname().split('.')[0]
+        with open(lock_file, 'w') as f:
+            f.write('{}-{}'.format(_host, _pid))
+
+        return True
+
+
+def unlock_flagfile(lock_file):
+    """
+    Remove the flagfile to unlock the process
+
+    :param lock_file: flag file use to lock the process
+    :return: None
+    """
+    if os.path.exists(lock_file):
+        os.remove(lock_file)

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -522,7 +522,7 @@ class Processor_v3(object):
 
         # Append the post command that runs after main
         if self.command_post:
-            txt += self.build_command(self.command_post)
+            txt += self.build_command(self.command_post, var2val)
 
         # Finish with a newline
         txt += '\"\n'

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -516,14 +516,14 @@ class Processor_v3(object):
         # Build and append the pre command that runs before main
         if self.command_pre:
             txt += self.build_command(self.command_pre, var2val)
-            txt += '\n\n'
+            txt += ' && '
 
         # Build and append the main command
         txt += self.build_command(self.command, var2val)
 
         # Append the post command that runs after main
         if self.command_post:
-            txt += '\n\n'
+            txt += ' && '
             txt += self.build_command(self.command_post, var2val)
 
         # Finish with a newline

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -263,11 +263,14 @@ class Processor_v3(object):
                 # Prepend singularity imagedir
                 curc['path'] = os.path.join(self.singularity_imagedir, cpath)
 
-            if curc.get('primary', False):
-                self.container_path = curc.get('path')
-
             # Add to our containers list
             self.containers.append(curc)
+
+        # Set the primary container path
+        container_name = self.command['container']
+        for c in self.containers:
+            if c.get('name') == container_name:
+                self.container_path = c.get('path')
 
         # Check primary container
         if not self.container_path:
@@ -1502,11 +1505,14 @@ class SgpProcessor(Processor_v3):
                 # Prepend singularity imagedir
                 curc['path'] = os.path.join(self.singularity_imagedir, cpath)
 
-            if curc.get('primary', False):
-                self.container_path = curc.get('path')
-
             # Add to our containers list
             self.containers.append(curc)
+
+        # Set the primary container path
+        container_name = self.command['container']
+        for c in self.containers:
+            if c.get('name') == container_name:
+                self.container_path = c.get('path')
 
         # Check primary container
         if not self.container_path:

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -506,6 +506,8 @@ class Processor_v3(object):
         # Append arguments for the singularity entrypoint
         cargs = command.get('args', None)
         if cargs:
+            # Unescape and then escape double quotes
+            cargs = cargs.replace('\\"', '"').replace('"', '\\\"')
             command_txt = '{} {}'.format(command_txt, cargs)
 
         # Replace vars with values from var2val

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -516,12 +516,14 @@ class Processor_v3(object):
         # Build and append the pre command that runs before main
         if self.command_pre:
             txt += self.build_command(self.command_pre, var2val)
+            txt += '\n\n'
 
         # Build and append the main command
         txt += self.build_command(self.command, var2val)
 
         # Append the post command that runs after main
         if self.command_post:
+            txt += '\n\n'
             txt += self.build_command(self.command_post, var2val)
 
         # Finish with a newline

--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -968,7 +968,15 @@ class Processor_v3(object):
             name = a.get('name')
             self.iteration_sources.add(name)
 
-            types = [_.strip() for _ in a['proctypes'].split(',')]
+            if 'proctypes' in a:
+                types = [_.strip() for _ in a['proctypes'].split(',')]
+            elif 'types' in a:
+                types = [_.strip() for _ in a['types'].split(',')]
+            else:
+                msg = 'no types for assessor:{}'.format(name)
+                LOGGER.error(msg)
+                raise AutoProcessorError(msg)
+
             resources = a.get('resources', [])
             artefact_required = False
             for r in resources:

--- a/dax/suppdf.py
+++ b/dax/suppdf.py
@@ -348,7 +348,7 @@ def load_info(assr_path, assr_obj):
     LOGGER.debug('suppdf:load_info:load_outputs')
     info['outputs'] = load_outputs(assr_path)
 
-    if is_sgp_assessor(assr_path):
+    if is_sgp_assessor(os.path.basename(assr_path)):
         info['proctype'] = info['assessor'].split('-x-')[2]
         info['session'] = {
             'PROJECT': assr['project_id'],


### PR DESCRIPTION
*Processor v3: add suppport for pre/post commands that run before/after the main command

Also:
*dax manager: improved reporting of errors in redcap settings
*dax manager: refactor uploading for auto clean up after crash
*dax undo: new command to rollback processing to need_inputs

These issues are addressed:
#311
#362
#345
