### PR TITLE
Update help string for --restart to make clear it applies to assessors of a given type.

### DIFF
--- a/bin/Xnat_tools/XnatSwitchProcessStatus
+++ b/bin/Xnat_tools/XnatSwitchProcessStatus
@@ -226,8 +226,6 @@ def filter_assessors(xnat, project, args, assessors, has_fs_datatypes=False,
     former_status = args.former_status
     if args.rerun:
         former_status = task.JOB_FAILED
-    elif args.restart:
-        former_status = None
     elif args.init:
         former_status = task.NO_DATA
     elif args.rerundiskq:

--- a/bin/Xnat_tools/XnatSwitchProcessStatus
+++ b/bin/Xnat_tools/XnatSwitchProcessStatus
@@ -226,6 +226,8 @@ def filter_assessors(xnat, project, args, assessors, has_fs_datatypes=False,
     former_status = args.former_status
     if args.rerun:
         former_status = task.JOB_FAILED
+    elif args.restart:
+        former_status = None
     elif args.init:
         former_status = task.NO_DATA
     elif args.rerundiskq:
@@ -672,8 +674,8 @@ the assessors from -t you changed are inputs to those assessors."
                         action="store_true", help=_h)
     parser.add_argument("--fullRegex", dest="full_regex", action='store_true',
                         help="Use full regex for filtering data.")
-    _h = "Restart the assessors by switching the status for all assessors \
-found to NEED_TO_RUN and delete previous resources."
+    _h = "Restart all assessors of a given process type by switching the \
+git status to NEED_TO_RUN and delete previous resources."
     parser.add_argument("--restart", dest="restart", action='store_true',
                         help=_h)
     _h = "Rerun the assessors by switching status to NEED_TO_RUN for \


### PR DESCRIPTION
…present.
 
Bug described at:  http://xnatbug.vandyxnat.org/bugzilla/show_bug.cgi?id=2501

Notes: Current change allows user to restart processors matching any former_status, not limited to JOB_FAILED.

Updated help string; current copy: Restart the assessors by switching the status for all assessors found to NEED_TO_RUN and delete previous resources.