### PR TITLE
Improve uploads

### DIFF
--- a/dax/dax_manager.py
+++ b/dax/dax_manager.py
@@ -909,6 +909,12 @@ class DaxManager(object):
 
 
 def run_upload_thread(logfile, xnat_host, pindex, alabel, pcount, resdir):
+    # Confirm that assessor is still in queue,
+    # it could have been uploaded by a different thread
+    if not os.path.exists(os.path.join(resdir, assessor_label)):
+        LOGGER.info(f'skipping, already uploaded:{assessor_label}')
+        return
+
     logging.getLogger('dax').handlers = []
     dax.bin.set_logger(logfile, debug=True)
     dax.bin.upload_thread(xnat_host, pindex, alabel, pcount, resdir)

--- a/dax/dax_manager.py
+++ b/dax/dax_manager.py
@@ -915,6 +915,12 @@ def run_upload_thread(logfile, xnat_host, pindex, alabel, pcount, resdir):
         LOGGER.info(f'skipping, already uploaded:{assessor_label}')
         return
 
+    # Pre-check for lock file to skip already uploading
+    if os.path.exists(os.path.join(
+        resdir, 'FlagFiles', f'{assessor_label}_Upload.txt')):
+        LOGGER.info(f'skipping, lock file found:{assessor_label}')
+        return
+
     logging.getLogger('dax').handlers = []
     dax.bin.set_logger(logfile, debug=True)
     dax.bin.upload_thread(xnat_host, pindex, alabel, pcount, resdir)

--- a/dax/dax_tools_utils.py
+++ b/dax/dax_tools_utils.py
@@ -496,10 +496,14 @@ unable to find XML file: %s'
                 try:
                     upload_resource(assessor_obj, resource, resource_path)
                 except Exception as e:
-                    _msg = 'failed to upload, skipping assessor:{}:{}'.format(
-                        resource_path, str(e))
-                    LOGGER.error(_msg)
-                    return
+                    try:
+                        LOGGER.warn('failed to upload, trying again')
+                        upload_resource(assessor_obj, resource, resource_path)
+                    except Exception as e:
+                        _msg = 'failed to upload, skipping assessor:{}:{}'.format(
+                            resource_path, str(e))
+                        LOGGER.error(_msg)
+                        return
 
         # after Upload
         if is_diskq_assessor(os.path.basename(assessor_path), resdir):


### PR DESCRIPTION
A few small changes to improve uploads.
*check that an assessor is still in the queue before starting to upload, this will prevent an extraneous log file.
*check that lock file does not exist before starting to upload, also prevents a log file.
*when a resource fails to upload, try again one time. if the retry succeeds, this will prevent having to re-upload the whole assessor on next pass.