### PR TITLE
os.rmdir was not removing the non-empty directories. shutil.rmtree re…

### DIFF
--- a/dax/XnatToBids.py
+++ b/dax/XnatToBids.py
@@ -72,15 +72,15 @@ def transform_to_bids(XNAT, DIRECTORY, project, BIDS_DIR, xnat_tag, LOGGER):
                                                 scan_file))
                                             os.remove(os.path.join(sess_path, scan, scan_resources, scan_file))
                                 LOGGER.info("\t\t>Removing XNAT resource %s folder" % (scan_resources))
-                                os.rmdir(os.path.join(sess_path, scan, scan_resources))
+                                shutil.rmtree(os.path.join(sess_path, scan, scan_resources))
                             LOGGER.info("\t>Removing XNAT scan %s folder" % (scan))
-                            os.rmdir(os.path.join(sess_path, scan))
+                            shutil.rmtree(os.path.join(sess_path, scan))
                     sess_idx = sess_idx + 1
                     LOGGER.info("\t>Removing XNAT session %s folder" % (sess))
-                    os.rmdir(sess_path)
+                    shutil.rmtree(sess_path)
                 subj_idx = subj_idx + 1
                 LOGGER.info("\t>Removing XNAT subject %s folder" % (subj))
-                os.rmdir(os.path.join(DIRECTORY, proj, subj))
+                shutil.rmtree(os.path.join(DIRECTORY, proj, subj))
     BIDS_PROJ_DIR = os.path.join(BIDS_DIR, project)
     dataset_description_file(BIDS_PROJ_DIR, XNAT, project)
 
@@ -359,7 +359,7 @@ def yaml_func_json_sidecar(XNAT, data_type, res_dir, scan_file, uri, project, xn
         print("\t\t>ERROR: the units in nifti header is not secs")
         print("\t\t>ERROR: BIDS Conversion not complete")
         func_folder = os.path.dirname(bids_res_path)
-        os.rmdir(func_folder)
+        shutil.rmtree(func_folder)
         sys.exit()
     TR_nifti = round(img.header['pixdim'][4].item(), 3)
     # If json not present - if TR in nifti and XNAT (project level) is equal, USE TR FROM NIFTI


### PR DESCRIPTION
…moves it

Tested this against a test BIDS directory with correct bids mapping and it works.