### PR TITLE
homedir relative to container

### DIFF
--- a/dax/processors_v3.py
+++ b/dax/processors_v3.py
@@ -45,7 +45,7 @@ LOGGER = logging.getLogger('dax')
 # which will already have the variables set for $INDIR and $OUTDIR
 SINGULARITY_BASEOPTS = (
     '--contain --cleanenv '
-    '--home $JOBDIR '
+    '--home /tmp/home '
     '--bind $INDIR:/INPUTS '
     '--bind $OUTDIR:/OUTPUTS '
     '--bind $JOBDIR:/tmp '


### PR DESCRIPTION
simplifying/shortening home dir path, https://bug.xnat.vanderbilt.edu/bugzilla/show_bug.cgi?id=3054

Came up because fmriprep was using the home dir for working space, and the path had too many characters due to the repeated long temp dir name. This is already fixed for fmriprep but maybe we should make this change anyway?
