### PR TITLE
Update dax_manager.py

### DIFF
--- a/dax/dax_manager.py
+++ b/dax/dax_manager.py
@@ -154,8 +154,13 @@ class DaxProjectSettingsManager(object):
         self.metadata = self._redcap.metadata
 
     def _load_records(self):
-        # Build the list of _complete fields from lists of modules/procesors
+        # Build the list of _complete fields from lists of modules/processors
         field_list = self._redcap.field_names + ['general_complete']
+
+        # Ignore task, analysis, processors forms
+        field_list = [x for x in field_list if not x.startswith('task_')]
+        field_list = [x for x in field_list if not x.startswith('analysis_')]
+        field_list = [x for x in field_list if not x.startswith('processor')]
 
         p = DaxProjectSettingsManager.PROC_PREFIX
         s = '_complete'
@@ -165,6 +170,7 @@ class DaxProjectSettingsManager(object):
         s = '_complete'
         field_list += [p + f + s for f in self.module_names]
 
+        LOGGER.info(f'querying redcap, fields:{field_list}')
         self.records = self._redcap.export_records(
             fields=field_list, raw_or_label='label')
 


### PR DESCRIPTION
In dax_manager, Filter out task/analysis/processor tables when loading main project records from REDCap. Including these was causing OOM issues on REDCap side and preventing dax_manager from running at all.