### PR TITLE
Count rcq jobs for group, not user

### DIFF
--- a/dax/cluster.py
+++ b/dax/cluster.py
@@ -52,7 +52,7 @@ def cj_subcmd(cmd):
         return int(output)
 
 
-def count_jobs(resdir,force_no_qsub=False):
+def count_jobs(resdir, force_no_qsub=False):
     """
     Count the number of jobs in the queue on the cluster
 
@@ -65,6 +65,30 @@ def count_jobs(resdir,force_no_qsub=False):
     elif command_found(cmd=DAX_SETTINGS.get_cmd_submit()):
         launched = cj_subcmd(DAX_SETTINGS.get_cmd_count_jobs_launched())
         pending = cj_subcmd(DAX_SETTINGS.get_cmd_count_jobs_pending())
+        cmd = DAX_SETTINGS.get_cmd_count_pendinguploads()
+        cmd = cmd.safe_substitute({'resdir': resdir})
+        pendinguploads = cj_subcmd(cmd)
+        return (launched, pending, pendinguploads)
+    else:
+        LOGGER.error('ERROR: failed to find cluster commands')
+        raise ClusterLaunchException
+
+
+def count_jobs_rcq(resdir, job_rungroup, force_no_qsub=False):
+    """
+    Count the number of jobs in the queue on the cluster
+
+    :return: number of jobs in the queue. tuple of
+             (launched, pending, pendinguploads)
+    """
+    if force_no_qsub:
+        LOGGER.info(' Running locally. No queue with jobs.')
+        return (0, 0, 0)
+    elif command_found(cmd=DAX_SETTINGS.get_cmd_submit()):
+        launched = cj_subcmd(DAX_SETTINGS.get_cmd_count_jobs_launched_rcq().
+            safe_substitute({'job_rungroup': job_rungroup))
+        pending = cj_subcmd(DAX_SETTINGS.get_cmd_count_jobs_pending_rcq().
+            safe_substitute({'job_rungroup': job_rungroup))
         cmd = DAX_SETTINGS.get_cmd_count_pendinguploads()
         cmd = cmd.safe_substitute({'resdir': resdir})
         pendinguploads = cj_subcmd(cmd)

--- a/dax/dax_settings.py
+++ b/dax/dax_settings.py
@@ -22,7 +22,7 @@ SLURM_COUNTJOBS_PENDING = 'squeue --me -t PENDING --noheader | wc -l'
 
 SLURM_COUNTJOBS_LAUNCHED_RCQ = 'squeue -A ${job_rungroup} --noheader | wc -l'
 
-SLURM_COUNTJOBS_PENDING_RCQ = 'squeue --A ${job_rungroup} -t PENDING --noheader | wc -l'
+SLURM_COUNTJOBS_PENDING_RCQ = 'squeue -A ${job_rungroup} -t PENDING --noheader | wc -l'
 
 SLURM_COUNT_PENDINGUPLOADS = 'ls -d ${resdir}/*-x-* |wc -l'
 

--- a/dax/dax_settings.py
+++ b/dax/dax_settings.py
@@ -20,6 +20,10 @@ SLURM_COUNTJOBS_LAUNCHED = 'squeue --me --noheader | wc -l'
 
 SLURM_COUNTJOBS_PENDING = 'squeue --me -t PENDING --noheader | wc -l'
 
+SLURM_COUNTJOBS_LAUNCHED_RCQ = 'squeue -A ${job_rungroup} --noheader | wc -l'
+
+SLURM_COUNTJOBS_PENDING_RCQ = 'squeue --A ${job_rungroup} -t PENDING --noheader | wc -l'
+
 SLURM_COUNT_PENDINGUPLOADS = 'ls -d ${resdir}/*-x-* |wc -l'
 
 SLURM_JOBNODE = "sacct -j ${jobid}.batch --format NodeList --noheader"
@@ -121,6 +125,12 @@ class DAX_Settings(object):
 
     def get_cmd_count_jobs_pending(self):
         return SLURM_COUNTJOBS_PENDING
+
+    def get_cmd_count_jobs_launched_rcq(self):
+        return SLURM_COUNTJOBS_LAUNCHED_RCQ
+
+    def get_cmd_count_jobs_pending_rcq(self):
+        return SLURM_COUNTJOBS_PENDING_RCQ
 
     def get_cmd_count_pendinguploads(self):
         return Template(SLURM_COUNT_PENDINGUPLOADS)

--- a/dax/rcq/analysislauncher.py
+++ b/dax/rcq/analysislauncher.py
@@ -8,7 +8,7 @@ from datetime import datetime
 import yaml
 import requests
 
-from ..cluster import PBS, count_jobs
+from ..cluster import PBS, count_jobs_rcq
 from ..lockfiles import lock_flagfile, unlock_flagfile
 from .projectinfo import load_project_info
 from ..utilities import get_this_instance, parse_list
@@ -284,7 +284,7 @@ class AnalysisLauncher(object):
                 # Launch jobs
                 updates = []
                 for i, cur in enumerate(launch_list):
-                    launched, pending, uploads = count_jobs(self._resdir)
+                    launched, pending, uploads = count_jobs_rcq(self._resdir, instance_settings['main_rungroup'])
                     logger.info(f'Cluster:{launched}/{q_limit} total, {pending}/{p_limit} pending, {uploads}/{u_limit} uploads')
 
                     if launched >= q_limit:

--- a/dax/rcq/tasklauncher.py
+++ b/dax/rcq/tasklauncher.py
@@ -9,7 +9,7 @@ import shutil
 import time
 
 from ..processors import load_from_yaml
-from ..cluster import PBS, count_jobs
+from ..cluster import PBS, count_jobs_rcq
 from ..lockfiles import lock_flagfile, unlock_flagfile
 
 
@@ -149,7 +149,7 @@ class TaskLauncher(object):
                 # Launch jobs
                 updates = []
                 for i, t in enumerate(launch_list):
-                    launched, pending, uploads = count_jobs(resdir)
+                    launched, pending, uploads = count_jobs_rcq(resdir, instance_settings['main_rungroup'])
                     logger.info(f'Cluster:{launched}/{q_limit} total, {pending}/{p_limit} pending, {uploads}/{u_limit} uploads')
 
                     if launched >= q_limit:


### PR DESCRIPTION
This should combine limits across daily/archive accounts when they share a rungroup, so that archive account won't launch jobs if daily's pending is full, etc.

Not really sure how to test - @bud42 got any thoughts?

This is distinct from the other matter (handling bulk launches on a single user)