### PR TITLE
Include hidden files when zipping a DIR for upload

### DIFF
--- a/dax/XnatUtils.py
+++ b/dax/XnatUtils.py
@@ -1961,7 +1961,7 @@ def upload_folder_to_obj(directory, resource_obj, resource_label, remove=False,
 
     # Zip all the files in the directory
     os.chdir(directory)
-    os.system('zip -r %s * > /dev/null' % fzip)
+    os.system('zip -r %s . > /dev/null' % fzip)
     # upload
     resource_obj.put_zip(os.path.join(directory, fzip), overwrite=True,
                          extract=extract)

--- a/dax/dax_settings.py
+++ b/dax/dax_settings.py
@@ -24,7 +24,7 @@ SLURM_COUNTJOBS_LAUNCHED_RCQ = 'squeue -A ${job_rungroup} --noheader | wc -l'
 
 SLURM_COUNTJOBS_PENDING_RCQ = 'squeue -A ${job_rungroup} -t PENDING --noheader | wc -l'
 
-SLURM_COUNT_PENDINGUPLOADS = 'find ${resdir} -maxdepth 2 -name READY_TO_UPLOAD.txt |wc -l'
+SLURM_COUNT_PENDINGUPLOADS = 'ls -d ${resdir}/*-x-* |wc -l'
 
 SLURM_JOBNODE = "sacct -j ${jobid}.batch --format NodeList --noheader"
 

--- a/dax/dax_settings.py
+++ b/dax/dax_settings.py
@@ -24,7 +24,7 @@ SLURM_COUNTJOBS_LAUNCHED_RCQ = 'squeue -A ${job_rungroup} --noheader | wc -l'
 
 SLURM_COUNTJOBS_PENDING_RCQ = 'squeue -A ${job_rungroup} -t PENDING --noheader | wc -l'
 
-SLURM_COUNT_PENDINGUPLOADS = 'ls -d ${resdir}/*-x-* |wc -l'
+SLURM_COUNT_PENDINGUPLOADS = 'find ${resdir} -maxdepth 2 -name READY_TO_UPLOAD.txt |wc -l'
 
 SLURM_JOBNODE = "sacct -j ${jobid}.batch --format NodeList --noheader"
 


### PR DESCRIPTION
Not tested.

FSL FEAT output dir includes hidden files/dirs that are critical for the HTML reports.