### PR TITLE
Create XnatDownloadGUI

### DIFF
--- a/bin/supplemental_tools/XnatDownloadGUI
+++ b/bin/supplemental_tools/XnatDownloadGUI
@@ -30,20 +30,16 @@ def start_download():
         session_id = 'all'
 
     if scan_id and not scan_resource:
-        scan_resource = 'all'
-        scan_comm = f" -s {scan_id} --rs {scan_resource}"
+        scan_comm = f" -s {scan_id} --rs all"
     elif not scan_id and scan_resource:
-        scan_id = 'all'
-        scan_comm = f" -s {scan_id} --rs {scan_resource}"
+        scan_comm = f" -s all --rs {scan_resource}"
     elif scan_id and scan_resource:
         scan_comm = f" -s {scan_id} --rs {scan_resource}"
 
     if assessor_id and not assessor_resource:
-        assessor_resource = 'all'
-        assessor_comm = f" -a {assessor_id} --ra {assessor_resource}"
+        assessor_comm = f" -a {assessor_id} --ra all"
     elif not assessor_id and assessor_resource:
-        assessor_id = 'all'
-        assessor_comm = f" -a {assessor_id} --ra {assessor_resource}"
+        assessor_comm = f" -a all --ra {assessor_resource}"
     elif assessor_id and assessor_resource:
         assessor_comm = f" -a {assessor_id} --ra {assessor_resource}"
 

--- a/bin/supplemental_tools/XnatDownloadGUI
+++ b/bin/supplemental_tools/XnatDownloadGUI
@@ -17,6 +17,9 @@ def start_download():
     assessor_id = assessor_entry.get()
     assessor_resource = assessor_resource_entry.get()
 
+    scan_comm = ""
+    assessor_comm = ""
+
     if not project_id:
         messagebox.showerror("No Project", "Project ID is required!")
 
@@ -26,24 +29,33 @@ def start_download():
     if not session_id:
         session_id = 'all'
 
-    if not scan_id:
-        scan_id = 'all'
-
-    if not scan_resource:
+    if scan_id and not scan_resource:
         scan_resource = 'all'
+        scan_comm = f" -s {scan_id} --rs {scan_resource}"
+    elif not scan_id and scan_resource:
+        scan_id = 'all'
+        scan_comm = f" -s {scan_id} --rs {scan_resource}"
+    elif scan_id and scan_resource:
+        scan_comm = f" -s {scan_id} --rs {scan_resource}"
 
-    if not assessor_id:
-        assessor_id = 'all'
-
-    if not assessor_resource:
+    if assessor_id and not assessor_resource:
         assessor_resource = 'all'
+        assessor_comm = f" -a {assessor_id} --ra {assessor_resource}"
+    elif not assessor_id and assessor_resource:
+        assessor_id = 'all'
+        assessor_comm = f" -a {assessor_id} --ra {assessor_resource}"
+    elif assessor_id and assessor_resource:
+        assessor_comm = f" -a {assessor_id} --ra {assessor_resource}"
 
     # Ask for download directory
     output_dir = filedialog.askdirectory(title="Select Output Directory")
 
+    XD_comm = f"XnatDownload -p {project_id} -d {output_dir} --subj {subject_id} --sess {session_id}"
+
     # XnatDownload
-    XD = f"XnatDownload -p {project_id} -d {output_dir} --subj {subject_id} --sess {session_id} -s {scan_id} --rs {scan_resource} -a {assessor_id} --ra {assessor_resource}"
-    subprocess.run(XD, shell=True)
+    full_comm = XD_comm + scan_comm + assessor_comm
+    print(full_comm) 
+    subprocess.run(full_comm, shell=True)
 
     # Output on command line
     print(f"Downloading project {project_id} to {output_dir}...")

--- a/bin/supplemental_tools/XnatDownloadGUI
+++ b/bin/supplemental_tools/XnatDownloadGUI
@@ -54,7 +54,6 @@ def start_download():
 
     # XnatDownload
     full_comm = XD_comm + scan_comm + assessor_comm
-    print(full_comm) 
     subprocess.run(full_comm, shell=True)
 
     # Output on command line

--- a/bin/supplemental_tools/XnatDownloadGUI
+++ b/bin/supplemental_tools/XnatDownloadGUI
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+
+import subprocess
+import tkinter as tk
+from tkinter import filedialog
+from tkinter import ttk
+from tkinter import messagebox
+
+
+def start_download():
+    # Grab information
+    project_id = project_entry.get()
+    subject_id = subject_entry.get()
+    session_id = session_entry.get()
+    scan_id = scan_entry.get()
+    scan_resource = scan_resource_entry.get()
+    assessor_id = assessor_entry.get()
+    assessor_resource = assessor_resource_entry.get()
+
+    if not project_id:
+        messagebox.showerror("No Project", "Project ID is required!")
+
+    if not subject_id:
+        subject_id = 'all'
+
+    if not session_id:
+        session_id = 'all'
+
+    if not scan_id:
+        scan_id = 'all'
+
+    if not scan_resource:
+        scan_resource = 'all'
+
+    if not assessor_id:
+        assessor_id = 'all'
+
+    if not assessor_resource:
+        assessor_resource = 'all'
+
+    # Ask for download directory
+    output_dir = filedialog.askdirectory(title="Select Output Directory")
+
+    # XnatDownload
+    XD = f"XnatDownload -p {project_id} -d {output_dir} --subj {subject_id} --sess {session_id} -s {scan_id} --rs {scan_resource} -a {assessor_id} --ra {assessor_resource}"
+    subprocess.run(XD, shell=True)
+
+    # Output on command line
+    print(f"Downloading project {project_id} to {output_dir}...")
+
+
+# Create/Size the main window
+root = tk.Tk()
+root.geometry('640x640')
+root.configure(bg="lightgrey")
+root.title("XNAT Downloader")
+
+# Add input fields - Project ID
+tk.Label(root, text="Project ID:").pack(pady=5)
+project_entry = tk.Entry(root)
+project_entry.pack(pady=5)
+
+# Add input fields - Subject ID 
+tk.Label(root, text="Subject ID:").pack(pady=5)
+subject_entry = tk.Entry(root)
+subject_entry.pack(pady=5)
+
+# Add input fields - Session ID
+tk.Label(root, text="Session ID:").pack(pady=5)
+session_entry = tk.Entry(root)
+session_entry.pack(pady=5)
+
+# Add input field - Scan ID
+tk.Label(root, text="Scan ID:").pack(pady=5)
+scan_entry = tk.Entry(root)
+scan_entry.pack(pady=5)
+
+# Add input field - Scan Resource
+tk.Label(root, text="Scan Resource:").pack(pady=5)
+scan_resource_entry = tk.Entry(root)
+scan_resource_entry.pack(pady=5)
+
+# Add input field - Assessor ID
+tk.Label(root, text="Assessor ID:").pack(pady=5)
+assessor_entry = tk.Entry(root)
+assessor_entry.pack(pady=5)
+
+# Add input field - Assessor Resource
+tk.Label(root, text="Assessor Resource:").pack(pady=5)
+assessor_resource_entry = tk.Entry(root)
+assessor_resource_entry.pack(pady=5)
+
+# Button creation and start_download call
+tk.Button(root, fg="blue", text="Select Output Directory and Start", command=start_download).pack(pady=20)
+
+# Keep window open
+root.mainloop()

--- a/bin/supplemental_tools/XnatDownloadGUI
+++ b/bin/supplemental_tools/XnatDownloadGUI
@@ -59,46 +59,50 @@ def start_download():
 # Create/Size the main window
 root = tk.Tk()
 root.geometry('640x640')
-root.configure(bg="lightgrey")
+root.configure(bg="#033769")
 root.title("XNAT Downloader")
 
-# Add input fields - Project ID
-tk.Label(root, text="Project ID:").pack(pady=5)
-project_entry = tk.Entry(root)
-project_entry.pack(pady=5)
+frame = tk.Frame(root,width=620,height=620)
+frame.pack(padx=30, pady=30)
+frame.configure(bg="lightgrey")
 
-# Add input fields - Subject ID 
-tk.Label(root, text="Subject ID:").pack(pady=5)
-subject_entry = tk.Entry(root)
-subject_entry.pack(pady=5)
+# Add input fields - Project ID
+tk.Label(frame, text="Project ID:").pack(pady=5)
+project_entry = tk.Entry(frame)
+project_entry.pack(pady=5, padx=100)
+
+# Add input fields - Subject ID
+tk.Label(frame, text="Subject ID:").pack(pady=5)
+subject_entry = tk.Entry(frame)
+subject_entry.pack(pady=5, padx=100)
 
 # Add input fields - Session ID
-tk.Label(root, text="Session ID:").pack(pady=5)
-session_entry = tk.Entry(root)
-session_entry.pack(pady=5)
+tk.Label(frame, text="Session ID:").pack(pady=5)
+session_entry = tk.Entry(frame)
+session_entry.pack(pady=5, padx=100)
 
 # Add input field - Scan ID
-tk.Label(root, text="Scan ID:").pack(pady=5)
-scan_entry = tk.Entry(root)
-scan_entry.pack(pady=5)
+tk.Label(frame, text="Scan ID:").pack(pady=5)
+scan_entry = tk.Entry(frame)
+scan_entry.pack(pady=5, padx=100)
 
 # Add input field - Scan Resource
-tk.Label(root, text="Scan Resource:").pack(pady=5)
-scan_resource_entry = tk.Entry(root)
-scan_resource_entry.pack(pady=5)
+tk.Label(frame, text="Scan Resource:").pack(pady=5)
+scan_resource_entry = tk.Entry(frame)
+scan_resource_entry.pack(pady=5, padx=100)
 
 # Add input field - Assessor ID
-tk.Label(root, text="Assessor ID:").pack(pady=5)
-assessor_entry = tk.Entry(root)
-assessor_entry.pack(pady=5)
+tk.Label(frame, text="Assessor ID:").pack(pady=5)
+assessor_entry = tk.Entry(frame)
+assessor_entry.pack(pady=5, padx=100)
 
 # Add input field - Assessor Resource
-tk.Label(root, text="Assessor Resource:").pack(pady=5)
-assessor_resource_entry = tk.Entry(root)
-assessor_resource_entry.pack(pady=5)
+tk.Label(frame, text="Assessor Resource:").pack(pady=5)
+assessor_resource_entry = tk.Entry(frame)
+assessor_resource_entry.pack(pady=5, padx=100)
 
 # Button creation and start_download call
-tk.Button(root, fg="blue", text="Select Output Directory and Start", command=start_download).pack(pady=20)
+tk.Button(frame, fg="#033769", bg="lightgrey", text="Select Output Directory and Start", command=start_download).pack(pady=20)
 
 # Keep window open
 root.mainloop()


### PR DESCRIPTION
Trying to build a GUI based XnatDownload tool that is BUILT-IN to python already.

This doesn't entirely work yet. Also doesn't have all the XnatDownload options. I'm also sure this can be approved upon readability wise as well. 

It's to a point where it puts a file in the directory given though. I'm not entirely sure about the actual XnatDownload part, since we've been messing around with the DB.

One problem I know of currently is that if you give it scan parameters, it will still look at ALL assessor info (and vice versa; assessor info, still looks at ALL scan info). Should be an easy fix, but just getting this somewhere. EXAMPLE: 
```
# Parameters :                                                 #
#     Directory            -> /Users/wilduett/Downloads        #
#     Project(s)           -> VUIIS_ABCD                       #
#     Subject(s)           -> 001                              #
#     Session(s)           -> 001_3TA_1                        #
#     Scan types           -> 201                              #
#     Resources Scan       -> NIFTI                            #
#     Process types        -> all                              #
#     Resources Process    -> all                              #
```

If you have any thoughts or can improve, go ahead!